### PR TITLE
Use typescript version of no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
   plugins: ["react", "react-hooks", "@typescript-eslint"],
   rules: {
     "dot-notation": "off",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
     "no-constant-condition": ["error", { checkLoops: false }],
   },
 };


### PR DESCRIPTION
See: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md

The plain `no-unused-vars` incorrectly warns against enum elements and argument names within interface definitions, etc. See [here](https://github.com/P-bibs/CODAP-flow/runs/2557748946#step:5:73). We are already using `@typescript-eslint/no-unused-vars`, which has the correct behavior.