### PR TITLE
fix font difference in purpose statement on firefox

### DIFF
--- a/src/components/transformer-template/styles/DefinitionCreator.css
+++ b/src/components/transformer-template/styles/DefinitionCreator.css
@@ -7,6 +7,7 @@
 .purpose-statement {
   font-family: "Montserrat", sans-serif;
   font-weight: 500;
+  font-size: 13px;
   padding: 5px;
   resize: none;
   margin-top: 5px;


### PR DESCRIPTION
Apparently Firefox wanted us to be explicit about the font-size in the purpose statement. Now the sizes are consistent between the name/purpose statement inputs across browsers. 