### PR TITLE
use `preventReorg` to make output dataset attributes non-draggable

### DIFF
--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -590,6 +590,7 @@ async function createDataContext({
   title,
   collections,
   metadata,
+  preventReorg,
 }: DataContext): Promise<CodapIdentifyingInfo> {
   return new Promise<CodapIdentifyingInfo>((resolve, reject) =>
     phone.call(
@@ -601,6 +602,7 @@ async function createDataContext({
           title: title !== undefined ? title : name,
           collections,
           metadata,
+          preventReorg,
         },
       },
       (response) => {
@@ -651,6 +653,7 @@ export async function createContextWithDataSet(
     title,
     metadata,
     collections: dataset.collections,
+    preventReorg: !dataset.editable,
   });
 
   await insertDataItems(newDatasetDescription.name, dataset.records);

--- a/src/lib/codapPhone/types.ts
+++ b/src/lib/codapPhone/types.ts
@@ -396,6 +396,7 @@ export interface DataContext {
   description?: string;
   collections: Collection[];
   metadata?: ContextMetadata;
+  preventReorg?: boolean;
 }
 
 export interface ReturnedDataContext extends Omit<DataContext, "collections"> {

--- a/src/transformers/__tests__/data.ts
+++ b/src/transformers/__tests__/data.ts
@@ -132,6 +132,7 @@ export function cloneDataSet(dataset: DataSet): DataSet {
   return {
     collections: dataset.collections.map((coll) => cloneCollection(coll)),
     records: dataset.records.map((rec) => shallowCopy(rec)),
+    editable: dataset.editable,
   };
 }
 

--- a/src/transformers/__tests__/editableCopy.test.ts
+++ b/src/transformers/__tests__/editableCopy.test.ts
@@ -22,7 +22,10 @@ import {
  * @param dataset The dataset to check.
  * @returns true if all attributes are editable, false otherwise.
  */
-function allAttributesAreEditable(dataset: DataSet): boolean {
+function isEditable(dataset: DataSet): boolean {
+  if (dataset.editable !== true) {
+    return false;
+  }
   for (const coll of dataset.collections) {
     for (const attr of coll.attrs || []) {
       if (!attr.editable) {
@@ -41,8 +44,10 @@ function allAttributesAreEditable(dataset: DataSet): boolean {
  * @param dataset A dataset to ignore the editability of.
  * @returns A copy of the input with all attribute editability made undefined.
  */
-function ignoreAttributeEditability(dataset: DataSet): DataSet {
+function ignoreEditability(dataset: DataSet): DataSet {
   const copy = cloneDataSet(dataset);
+
+  copy.editable = undefined;
 
   copy.collections.forEach((coll) => {
     coll.attrs?.forEach((attr) => (attr.editable = undefined));
@@ -54,115 +59,98 @@ function ignoreAttributeEditability(dataset: DataSet): DataSet {
 describe("editable copy produces an exact copy of the input (barring attribute editability)", () => {
   test("uneditable dataset", () => {
     expect(
-      ignoreAttributeEditability(
-        uncheckedEditableCopy(DATASET_WITH_UNEDITABLE_ATTRS)
-      )
-    ).toEqual(ignoreAttributeEditability(DATASET_WITH_UNEDITABLE_ATTRS));
+      ignoreEditability(uncheckedEditableCopy(DATASET_WITH_UNEDITABLE_ATTRS))
+    ).toEqual(ignoreEditability(DATASET_WITH_UNEDITABLE_ATTRS));
   });
   test("dataset A", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(DATASET_A))
-    ).toEqual(ignoreAttributeEditability(DATASET_A));
+    expect(ignoreEditability(uncheckedEditableCopy(DATASET_A))).toEqual(
+      ignoreEditability(DATASET_A)
+    );
   });
   test("dataset B", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(DATASET_B))
-    ).toEqual(ignoreAttributeEditability(DATASET_B));
+    expect(ignoreEditability(uncheckedEditableCopy(DATASET_B))).toEqual(
+      ignoreEditability(DATASET_B)
+    );
   });
   test("grades wider", () => {
     expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(GRADES_DATASET_WIDER))
-    ).toEqual(ignoreAttributeEditability(GRADES_DATASET_WIDER));
+      ignoreEditability(uncheckedEditableCopy(GRADES_DATASET_WIDER))
+    ).toEqual(ignoreEditability(GRADES_DATASET_WIDER));
   });
   test("grades longer", () => {
     expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(GRADES_DATASET_LONGER))
-    ).toEqual(ignoreAttributeEditability(GRADES_DATASET_LONGER));
+      ignoreEditability(uncheckedEditableCopy(GRADES_DATASET_LONGER))
+    ).toEqual(ignoreEditability(GRADES_DATASET_LONGER));
   });
   test("dataset with meta", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(DATASET_WITH_META))
-    ).toEqual(ignoreAttributeEditability(DATASET_WITH_META));
+    expect(ignoreEditability(uncheckedEditableCopy(DATASET_WITH_META))).toEqual(
+      ignoreEditability(DATASET_WITH_META)
+    );
   });
   test("dataset with empty records", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(EMPTY_RECORDS))
-    ).toEqual(ignoreAttributeEditability(EMPTY_RECORDS));
+    expect(ignoreEditability(uncheckedEditableCopy(EMPTY_RECORDS))).toEqual(
+      ignoreEditability(EMPTY_RECORDS)
+    );
   });
   test("census dataset", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(CENSUS_DATASET))
-    ).toEqual(ignoreAttributeEditability(CENSUS_DATASET));
+    expect(ignoreEditability(uncheckedEditableCopy(CENSUS_DATASET))).toEqual(
+      ignoreEditability(CENSUS_DATASET)
+    );
   });
   test("fully-featured dataset", () => {
     expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(FULLY_FEATURED_DATASET))
-    ).toEqual(ignoreAttributeEditability(FULLY_FEATURED_DATASET));
+      ignoreEditability(uncheckedEditableCopy(FULLY_FEATURED_DATASET))
+    ).toEqual(ignoreEditability(FULLY_FEATURED_DATASET));
   });
   test("types dataset", () => {
-    expect(
-      ignoreAttributeEditability(uncheckedEditableCopy(TYPES_DATASET))
-    ).toEqual(ignoreAttributeEditability(TYPES_DATASET));
+    expect(ignoreEditability(uncheckedEditableCopy(TYPES_DATASET))).toEqual(
+      ignoreEditability(TYPES_DATASET)
+    );
   });
 });
 
 describe("output of editable copy can be edited", () => {
   test("uneditable dataset", () => {
     expect(
-      allAttributesAreEditable(
-        uncheckedEditableCopy(DATASET_WITH_UNEDITABLE_ATTRS)
-      )
+      isEditable(uncheckedEditableCopy(DATASET_WITH_UNEDITABLE_ATTRS))
     ).toBe(true);
   });
   test("dataset A", () => {
-    expect(allAttributesAreEditable(uncheckedEditableCopy(DATASET_A))).toBe(
-      true
-    );
+    expect(isEditable(uncheckedEditableCopy(DATASET_A))).toBe(true);
   });
   test("dataset B", () => {
-    expect(allAttributesAreEditable(uncheckedEditableCopy(DATASET_B))).toBe(
-      true
-    );
+    expect(isEditable(uncheckedEditableCopy(DATASET_B))).toBe(true);
   });
   test("grades wider", () => {
-    expect(
-      allAttributesAreEditable(uncheckedEditableCopy(GRADES_DATASET_WIDER))
-    ).toBe(true);
+    expect(isEditable(uncheckedEditableCopy(GRADES_DATASET_WIDER))).toBe(true);
   });
   test("grades longer", () => {
-    expect(
-      allAttributesAreEditable(uncheckedEditableCopy(GRADES_DATASET_LONGER))
-    ).toBe(true);
+    expect(isEditable(uncheckedEditableCopy(GRADES_DATASET_LONGER))).toBe(true);
   });
   test("dataset with meta", () => {
-    expect(
-      allAttributesAreEditable(uncheckedEditableCopy(DATASET_WITH_META))
-    ).toBe(true);
+    expect(isEditable(uncheckedEditableCopy(DATASET_WITH_META))).toBe(true);
   });
   test("dataset with empty records", () => {
-    expect(allAttributesAreEditable(uncheckedEditableCopy(EMPTY_RECORDS))).toBe(
-      true
-    );
+    expect(isEditable(uncheckedEditableCopy(EMPTY_RECORDS))).toBe(true);
   });
   test("census dataset", () => {
-    expect(
-      allAttributesAreEditable(uncheckedEditableCopy(CENSUS_DATASET))
-    ).toBe(true);
+    expect(isEditable(uncheckedEditableCopy(CENSUS_DATASET))).toBe(true);
   });
   test("fully-featured dataset", () => {
-    expect(
-      allAttributesAreEditable(uncheckedEditableCopy(FULLY_FEATURED_DATASET))
-    ).toBe(true);
-  });
-  test("types dataset", () => {
-    expect(allAttributesAreEditable(uncheckedEditableCopy(TYPES_DATASET))).toBe(
+    expect(isEditable(uncheckedEditableCopy(FULLY_FEATURED_DATASET))).toBe(
       true
     );
+  });
+  test("types dataset", () => {
+    expect(isEditable(uncheckedEditableCopy(TYPES_DATASET))).toBe(true);
   });
 });
 
 describe("editable copy", () => {
   it("does nothing to fully empty dataset", () => {
-    expect(uncheckedEditableCopy(EMPTY_DATASET)).toEqual(EMPTY_DATASET);
+    expect(uncheckedEditableCopy(EMPTY_DATASET)).toEqual({
+      ...EMPTY_DATASET,
+      editable: true,
+    });
   });
 });

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -8,6 +8,7 @@ import { PartitionSaveState } from "./partition";
 export type DataSet = {
   collections: Collection[];
   records: Record<string, unknown>[];
+  editable?: boolean;
 };
 
 export type CodapLanguageType =

--- a/src/transformers/util.ts
+++ b/src/transformers/util.ts
@@ -531,6 +531,14 @@ export function extractAttributeAsNumeric(
   return numericValues;
 }
 
+/**
+ * Sets the dataset's mutability by setting all the attributes' `editable`
+ * property as well as the DataSet's `editable` property to the given value.
+ *
+ * @param dataset The dataset to produce a copy of with determined editability
+ * @param mutable Whether or not the copied dataset should be mutable.
+ * @returns A copy of the input that is either mutable or immutable.
+ */
 function changeDatasetMutability(dataset: DataSet, mutable: boolean): DataSet {
   const newCollections = dataset.collections.map(cloneCollection);
   for (const c of newCollections) {
@@ -539,6 +547,7 @@ function changeDatasetMutability(dataset: DataSet, mutable: boolean): DataSet {
     }
   }
   return {
+    editable: mutable,
     collections: newCollections,
     records: dataset.records,
   };


### PR DESCRIPTION
Uses the `preventReorg` property on data contexts to set/unset attribute draggability as part of the immutability of output tables produced by transformers.

Addresses #185. 