### PR TITLE
Update type contract UI

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -67,9 +67,9 @@ interface DropdownInit extends ComponentInit {
 }
 interface ExpressionInit extends ComponentInit {}
 interface TypeContractInit extends ComponentInit {
-  inputTypes: string[];
+  inputTypes: string[] | string;
   inputTypeDisabled?: boolean;
-  outputTypes: string[];
+  outputTypes: string[] | string;
   outputTypeDisabled?: boolean;
 }
 export type TransformerTemplateInit = {

--- a/src/components/ui-components/TypeSelector.tsx
+++ b/src/components/ui-components/TypeSelector.tsx
@@ -2,16 +2,22 @@ import React, { ReactElement } from "react";
 import { Select } from ".";
 
 interface TypeSelectorProps {
-  inputTypes: string[];
+  inputTypes: string[] | string;
   selectedInputType: string;
   inputTypeOnChange?: React.ChangeEventHandler<HTMLSelectElement>;
   inputTypeDisabled?: boolean;
-  outputTypes: string[];
+  outputTypes: string[] | string;
   selectedOutputType: string;
   outputTypeOnChange?: React.ChangeEventHandler<HTMLSelectElement>;
   outputTypeDisabled?: boolean;
 }
 
+/**
+ * A component that renders up to two dropdowns with the interface of a type
+ * contract. If a single string is specified for the `inputTypes` or
+ * `outputTypes` instead of an array then that string will be displayed instead
+ * of a dropdown
+ */
 export default function TypeSelector({
   inputTypes,
   selectedInputType,
@@ -24,21 +30,30 @@ export default function TypeSelector({
 }: TypeSelectorProps): ReactElement {
   return (
     <div style={{ marginTop: "5px" }}>
-      <Select
-        defaultValue="Type"
-        value={selectedInputType}
-        options={inputTypes.map((s) => ({ value: s, title: s }))}
-        onChange={inputTypeOnChange}
-        disabled={inputTypeDisabled}
-      />
+      Contract:{" "}
+      {typeof inputTypes === "object" ? (
+        <Select
+          defaultValue="Type"
+          value={selectedInputType}
+          options={inputTypes.map((s) => ({ value: s, title: s }))}
+          onChange={inputTypeOnChange}
+          disabled={inputTypeDisabled}
+        />
+      ) : (
+        <span style={{ fontFamily: "monospace" }}>{inputTypes}</span>
+      )}
       {" → "}
-      <Select
-        defaultValue="Type"
-        value={selectedOutputType}
-        options={outputTypes.map((s) => ({ value: s, title: s }))}
-        onChange={outputTypeOnChange}
-        disabled={outputTypeDisabled}
-      />
+      {typeof outputTypes === "object" ? (
+        <Select
+          defaultValue="Type"
+          value={selectedOutputType}
+          options={outputTypes.map((s) => ({ value: s, title: s }))}
+          onChange={outputTypeOnChange}
+          disabled={outputTypeDisabled}
+        />
+      ) : (
+        <span style={{ fontFamily: "monospace" }}>{outputTypes}</span>
+      )}
     </div>
   );
 }

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -802,8 +802,8 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "How to Filter",
-          inputTypes: ["row"],
-          outputTypes: ["boolean"],
+          inputTypes: "row",
+          outputTypes: "boolean",
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
@@ -834,7 +834,7 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Formula for Transformed Values",
-          inputTypes: ["row"],
+          inputTypes: "row",
           outputTypes: ["any", "string", "number", "boolean", "boundary"],
           inputTypeDisabled: true,
         },
@@ -871,7 +871,7 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Formula for Attribute Values",
-          inputTypes: ["row"],
+          inputTypes: "row",
           outputTypes: ["any", "string", "number", "boolean", "boundary"],
           inputTypeDisabled: true,
         },
@@ -949,7 +949,7 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Key expression",
-          inputTypes: ["row"],
+          inputTypes: "row",
           outputTypes: ["any", "string", "number", "boolean", "boundary"],
           inputTypeDisabled: true,
         },


### PR DESCRIPTION
This PR adds functionality that lets the type selector take a single value instead of a list of options. This will display the value as a raw string instead of a dropdown. It also adds `Context:` before the dropdowns to give the user more instruction.

![image](https://user-images.githubusercontent.com/40366824/127367728-970c50ac-a345-4c6b-9b61-495bb0a82256.png)
![image](https://user-images.githubusercontent.com/40366824/127367757-5e77f5f2-2071-4603-96c1-6fe774b9bc4a.png)
