### PR TITLE
Rename label, change wording

### DIFF
--- a/src/components/info-components/AboutInfo.tsx
+++ b/src/components/info-components/AboutInfo.tsx
@@ -47,8 +47,8 @@ function AboutInfo(): ReactElement {
           <h3>Getting Started</h3>
           <p>
             To get started with the Transformers plugin, check out the various
-            transformers in the “Transformer Type” dropdown. To learn more about
-            a specific transformer, click the “i” icon next to the dropdown.
+            transformers in the “Transformer” dropdown. To learn more about a
+            specific transformer, click the “i” icon next to the dropdown.
           </p>
 
           <h3>Authors</h3>

--- a/src/components/info-components/AboutInfo.tsx
+++ b/src/components/info-components/AboutInfo.tsx
@@ -54,7 +54,7 @@ function AboutInfo(): ReactElement {
           <h3>Authors</h3>
           <p>
             This plugin is brought to you by Paul Biberstein, Thomas Castleman,
-            and Jason Chen of the{" "}
+            and Jason Chen of{" "}
             <a
               href="https://cs.brown.edu/research/plt/"
               target="_blank"

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -137,7 +137,7 @@ function REPLView(): ReactElement {
   return (
     <div className="transformer-view">
       <div className="title-row">
-        <h3>Transformer Type</h3>
+        <h3>Transformer</h3>
 
         <AboutInfo />
       </div>


### PR DESCRIPTION
- Rename "Transformer Type" to "Transformer"
- Remove "the" from attribution