### PR TITLE
Add loading indicator to apply transformer button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 
-.loading, .initError {
+.codap-connection-loading, .initError {
   font-size: 14px;
   margin: 15px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ export const App = (): ReactElement => {
       </p>
     );
   } else if (status === "loading") {
-    return <p className="loading">Connecting to CODAP...</p>;
+    return <p className="codap-connection-loading">Connecting to CODAP...</p>;
   } else {
     return pluginContent;
   }

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import React, { useReducer, ReactElement, useEffect } from "react";
+import React, { useReducer, ReactElement, useEffect, useState } from "react";
 import {
   createText,
   getInteractiveFrame,
@@ -239,6 +239,8 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
     setErrMsg,
     activeTransformationsDispatch,
   } = props;
+
+  const [loading, setLoading] = useState<boolean>(false);
 
   const [state, setState] = useReducer(
     (
@@ -541,11 +543,19 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
       <div>
         <button
           id="applyTransformer"
-          onClick={
+          disabled={loading}
+          className={loading ? "loading" : ""}
+          onClick={() => {
+            // disable the button while the transformer is running
+            if (loading) return;
+
+            setLoading(true);
             transformerFunction.kind === "fullOverride"
-              ? () => transformerFunction.createFunc(props, state)
-              : transform
-          }
+              ? transformerFunction
+                  .createFunc(props, state)
+                  .then(() => setLoading(false))
+              : transform().then(() => setLoading(false));
+          }}
         >
           Apply Transformer
         </button>

--- a/src/components/transformer-template/styles/TransformerTemplate.css
+++ b/src/components/transformer-template/styles/TransformerTemplate.css
@@ -19,7 +19,8 @@
   content: " ";
   display: inline-block;
   position: absolute;
-  left: 50%;
+  /* Subtract half the elements width to truly center */
+  left: calc(50% - 5px);
   width: 10px;
   height: 10px;
   margin: 1px;

--- a/src/components/transformer-template/styles/TransformerTemplate.css
+++ b/src/components/transformer-template/styles/TransformerTemplate.css
@@ -2,8 +2,37 @@
 #applyTransformer {
   margin-top: 10px;
   background-color: #daeef1;
+  position: relative;
+
 }
 
 #applyTransformer:hover {
   background-color: #edf6f8;
+}
+
+#applyTransformer.loading {
+  background-color: rgb(171, 181, 184);
+  cursor: not-allowed;
+}
+
+#applyTransformer.loading:after {
+  content: " ";
+  display: inline-block;
+  position: absolute;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  margin: 1px;
+  border-radius: 50%;
+  border: 3px solid rgb(62, 65, 66);
+  border-color: rgb(62, 65, 66) transparent rgb(62, 65, 66) transparent;
+  animation: full-rotation 1.2s linear infinite;
+}
+@keyframes full-rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
I noticed that applying some transformers (especially if the table had boundaries) took long enough that it felt like nothing was happening for a moment when you hit `apply transformer`. I've added a loading spinner to help fix that. I opted for a loading spinner that appears on top of the button as opposed to the side to really reinforce the idea that the button is disabled while transformers are being applied. If you have alternate suggestions for stylng feel free to suggest them.
![image](https://user-images.githubusercontent.com/40366824/127659825-f1da20dd-170e-4dc8-bc89-0f5fbc21b333.png)
