### PR TITLE
Bring plugin to front when an error occurs

### DIFF
--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -316,6 +316,31 @@ export function notifyInteractiveFrameIsDirty(): Promise<void> {
   );
 }
 
+/**
+ * Sends a request to select (bring to front) the plugin's interactive frame
+ */
+export async function notifyInteractiveFrameWithSelect(): Promise<void> {
+  const id = (await getInteractiveFrame()).id;
+  return new Promise<void>((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Notify,
+        resource: resourceFromComponent(`${id}`),
+        values: {
+          request: "select",
+        },
+      },
+      (response) => {
+        if (response.success) {
+          resolve();
+        } else {
+          reject(new Error("Failed to notify component to select."));
+        }
+      }
+    )
+  );
+}
+
 export function getAllComponents(): Promise<ComponentListResponse["values"]> {
   return new Promise((resolve, reject) =>
     phone.call(

--- a/src/lib/codapPhone/types.ts
+++ b/src/lib/codapPhone/types.ts
@@ -150,6 +150,12 @@ export interface NotifyUndoChangeNoticeRequest {
     | { operation: "undoableActionPerformed"; logMessage?: string };
 }
 
+export interface NotifyComponentRequest {
+  action: CodapActions.Notify;
+  resource: string;
+  values: { request: "select" };
+}
+
 export interface EvalExpressionRequest {
   action: CodapActions.Notify;
   resource: CodapResource.FormulaEngine;
@@ -277,6 +283,7 @@ export type CodapPhone = {
     cb: (r: GetFunctionInfoResponse) => void
   ): void;
   call(r: NotifyUndoChangeNoticeRequest, cb: (r: CodapResponse) => void): void;
+  call(r: NotifyComponentRequest, cb: (r: CodapResponse) => void): void;
   call(r: CodapRequest[], cb: (r: CodapResponse[]) => void): void;
 };
 
@@ -577,6 +584,7 @@ export interface Guide extends CodapComponent {
 export type InteractiveFrame = {
   name: string;
   title: string;
+  id: number;
   version: string;
   dimensions: {
     width: number;

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -11,6 +11,7 @@ import transformerList, {
 import {
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
+  notifyInteractiveFrameWithSelect,
 } from "../lib/codapPhone";
 import {
   addInteractiveStateRequestListener,
@@ -24,6 +25,7 @@ import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
 import Select, { ValueType, ActionMeta } from "react-select";
 import TransformerInfo from "../components/info-components/TransformerInfo";
+import { useReducer } from "react";
 
 // These are the base transformer types represented as SavedTransformer
 // objects
@@ -65,7 +67,15 @@ function REPLView(): ReactElement {
   const [transformType, setTransformType] =
     useState<BaseTransformerName | null>(null);
 
-  const [errMsg, setErrMsg] = useState<string | null>(null);
+  const [errMsg, setErrMsg] = useReducer(
+    (oldState: string | null, newState: string | null): string | null => {
+      if (newState) {
+        notifyInteractiveFrameWithSelect();
+      }
+      return newState;
+    },
+    null
+  );
 
   // activeTransformations (first element of tuple) can be used to draw a diagram
   const [, activeTransformationsDispatch, wrappedDispatch] =

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useReducer } from "react";
 import { useState } from "react";
 import "./styles/Views.css";
 import ErrorDisplay from "../components/ui-components/Error";
@@ -7,6 +7,7 @@ import { TextArea, TextInput } from "../components/ui-components";
 import {
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
+  notifyInteractiveFrameWithSelect,
   updateInteractiveFrame,
 } from "../lib/codapPhone";
 import { useEffect } from "react";
@@ -31,7 +32,15 @@ function SavedDefinitionView({
 }: {
   transformer: SavedTransformer;
 }): ReactElement {
-  const [errMsg, setErrMsg] = useState<string | null>(null);
+  const [errMsg, setErrMsg] = useReducer(
+    (oldState: string | null, newState: string | null): string | null => {
+      if (newState) {
+        notifyInteractiveFrameWithSelect();
+      }
+      return newState;
+    },
+    null
+  );
   const [editable, setEditable] = useState<boolean>(false);
   const [savedTransformer, setSavedTransformer] = useState(urlTransformer);
   const [saveErr, setSaveErr] = useState<string | null>(null);


### PR DESCRIPTION
Whenever `setErrMsg` is called with a non-empty error message, an api request is sent to select the plugin. This causes it to be brought to the front of the workspace so the user is made aware an error occured.