### PR TITLE
Shorten type error messages

### DIFF
--- a/src/lib/utils/typeChecking.ts
+++ b/src/lib/utils/typeChecking.ts
@@ -1,5 +1,5 @@
 import { CodapLanguageType } from "../../transformers/types";
-import { prettyPrintCase } from "./prettyPrint";
+// import { prettyPrintCase } from "./prettyPrint";
 
 /**
  * Enum representing all type checking predicates in CODAP
@@ -27,9 +27,7 @@ export async function reportTypeErrorsForRecords(
   const errorIndices = await findTypeErrors(values, type, evalFormula);
   if (errorIndices.length !== 0) {
     throw new Error(
-      `Formula did not evaluate to ${type} for case ${prettyPrintCase(
-        records[errorIndices[0]]
-      )}`
+      `Formula did not evaluate to ${type} at case ${errorIndices[0]}`
     );
   }
 }


### PR DESCRIPTION
Rather than print the whole case that's erroring, we now only print the index. Any better suggestions? 

Old:
![Screenshot from 2021-08-02 15-09-45](https://user-images.githubusercontent.com/40366824/127911505-5f2fb835-3e94-4c0c-8c0d-c1660a457557.png)
New:
![Screenshot from 2021-08-02 15-08-10](https://user-images.githubusercontent.com/40366824/127911283-2fc23450-53f8-4671-bb48-3e53aded80ef.png)
