### PR TITLE
fixed updating errors for text outputs causing crash

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -329,7 +329,7 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
           type: ActiveTransformationActionTypes.ADD,
           newTransformation: {
             inputs,
-            extraDependencies: [],
+            extraDependencies: [textName],
             outputType: TransformationOutputType.TEXT,
             output: textName,
             transformer: base as DatasetCreatorTransformerName,

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -42,6 +42,7 @@ import {
   clearUndoAndRedoStacks,
   callAllContextUpdateHooks,
   callAllContextDeletedHooks,
+  callAllTextDeletedHooks,
 } from "./listeners";
 import {
   resourceFromContext,
@@ -206,6 +207,16 @@ function codapRequestHandler(
     callAllContextListeners();
     callback({ success: true });
     return;
+  }
+
+  // text component was deleted
+  if (
+    command.resource === CodapResource.Component &&
+    command.values.operation === "delete" &&
+    command.values.type === "DG.TextView"
+  ) {
+    // Call all text deleted hooks with the deleted text's name
+    callAllTextDeletedHooks(command.values.name);
   }
 
   if (

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -896,6 +896,24 @@ export async function createText(
   );
 }
 
+// export async function getText(name: string): Promise<CodapIdentifyingInfo> {
+//   return new Promise<CodapIdentifyingInfo>((resolve, reject) =>
+//     phone.call(
+//       {
+//         action: CodapActions.Get,
+//         resource: resourceFromComponent(name),
+//       },
+//       (response) => {
+//         if (response.success) {
+//           resolve(response.values);
+//         } else {
+//           reject(new Error("Failed to delete text"));
+//         }
+//       }
+//     )
+//   );
+// }
+
 export async function updateText(name: string, content: string): Promise<void> {
   return new Promise<void>((resolve, reject) =>
     phone.call(

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -896,24 +896,6 @@ export async function createText(
   );
 }
 
-// export async function getText(name: string): Promise<CodapIdentifyingInfo> {
-//   return new Promise<CodapIdentifyingInfo>((resolve, reject) =>
-//     phone.call(
-//       {
-//         action: CodapActions.Get,
-//         resource: resourceFromComponent(name),
-//       },
-//       (response) => {
-//         if (response.success) {
-//           resolve(response.values);
-//         } else {
-//           reject(new Error("Failed to delete text"));
-//         }
-//       }
-//     )
-//   );
-// }
-
 export async function updateText(name: string, content: string): Promise<void> {
   return new Promise<void>((resolve, reject) =>
     phone.call(

--- a/src/lib/codapPhone/listeners.ts
+++ b/src/lib/codapPhone/listeners.ts
@@ -211,3 +211,9 @@ export const [
   removeContextDeletedHook,
   callAllContextDeletedHooks,
 ] = makeContextHook();
+
+export const [
+  addTextDeletedHook,
+  removeTextDeletedHook,
+  callAllTextDeletedHooks,
+] = makeContextHook();

--- a/src/lib/codapPhone/types.ts
+++ b/src/lib/codapPhone/types.ts
@@ -386,6 +386,17 @@ export type CodapInitiatedCommand =
         operation: ContextChangeOperation;
         result?: Record<string, unknown>;
       }[];
+    }
+  | {
+      action: CodapActions.Notify;
+      resource: CodapResource.Component;
+      values: {
+        operation: "delete";
+        type: "DG.TextView";
+        id: number;
+        name: string;
+        title: string;
+      };
     };
 
 // The `metadata` property of data contexts is undocumented but described here:


### PR DESCRIPTION
This addresses part of #186 -- the unhandled rejection part where we tried to get a text component as a data context.

I also made it so that new updates cause the error message to clear before the update happens. That way, if an update error is fixed, the flowing through of the update will remove the error message.