### PR TITLE
invalidate cache for deleted contexts

### DIFF
--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -190,9 +190,11 @@ function codapRequestHandler(
     command.resource === CodapInitiatedResource.DocumentChangeNotice &&
     command.values.operation === DocumentChangeOperations.DataContextDeleted
   ) {
-    removeContextUpdateListenersForContext(command.values.deletedContext);
-    removeListenersWithDependency(command.values.deletedContext);
-    callAllContextDeletedHooks(command.values.deletedContext);
+    const deletedContext = command.values.deletedContext;
+    Cache.invalidateContext(deletedContext);
+    removeContextUpdateListenersForContext(deletedContext);
+    removeListenersWithDependency(deletedContext);
+    callAllContextDeletedHooks(deletedContext);
     callback({ success: true });
     return;
   }


### PR DESCRIPTION
Fixes #132, I think. I can't reproduce the erroring behavior mentioned there and I think it may be because our UI selectors have since gotten smarter about dealing with deleted datasets.

@stardust66, does this do everything necessary to invalidate the cache for the deleted context? Is there anything else I'm missing?