### PR TITLE
add a prompt to the filter expression

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -68,7 +68,7 @@ interface DropdownInit extends ComponentInit {
     value: string;
   }[];
 }
-interface ExpressionPromptInit extends ComponentInit {
+interface PromptInit extends ComponentInit {
   prompt: string;
 }
 interface ExpressionInit extends ComponentInit {}
@@ -91,8 +91,8 @@ export type TransformerTemplateInit = {
   textInput2?: TextInputInit;
   dropdown1?: DropdownInit;
   dropdown2?: DropdownInit;
-  expressionPrompt1?: ExpressionPromptInit;
-  expressionPrompt2?: ExpressionPromptInit;
+  prompt1?: PromptInit;
+  prompt2?: PromptInit;
   expression1?: ExpressionInit;
   expression2?: ExpressionInit;
   typeContract1?: TypeContractInit;
@@ -551,10 +551,7 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
           ) : (
             `${component} used but undefined`
           );
-        } else if (
-          component === "expressionPrompt1" ||
-          component === "expressionPrompt2"
-        ) {
+        } else if (component === "prompt1" || component === "prompt2") {
           return (
             <div className="input-group">
               <span>{init[component]?.prompt}</span>

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -68,6 +68,9 @@ interface DropdownInit extends ComponentInit {
     value: string;
   }[];
 }
+interface ExpressionPromptInit extends ComponentInit {
+  prompt: string;
+}
 interface ExpressionInit extends ComponentInit {}
 interface TypeContractInit extends ComponentInit {
   inputTypes: string[] | string;
@@ -88,6 +91,8 @@ export type TransformerTemplateInit = {
   textInput2?: TextInputInit;
   dropdown1?: DropdownInit;
   dropdown2?: DropdownInit;
+  expressionPrompt1?: ExpressionPromptInit;
+  expressionPrompt2?: ExpressionPromptInit;
   expression1?: ExpressionInit;
   expression2?: ExpressionInit;
   typeContract1?: TypeContractInit;
@@ -545,6 +550,15 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
             </div>
           ) : (
             `${component} used but undefined`
+          );
+        } else if (
+          component === "expressionPrompt1" ||
+          component === "expressionPrompt2"
+        ) {
+          return (
+            <div className="input-group">
+              <span>{init[component]?.prompt}</span>
+            </div>
           );
         } else if (component === "expression1" || component === "expression2") {
           return (

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -807,6 +807,10 @@ const transformerList: TransformerList = {
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
+        expressionPrompt1: {
+          title: "",
+          prompt: "Keep all rows that satisfy:",
+        },
         expression1: { title: "" },
       },
       transformerFunction: { kind: "datasetCreator", func: filter },

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -807,7 +807,7 @@ const transformerList: TransformerList = {
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
-        expressionPrompt1: {
+        prompt1: {
           title: "",
           prompt: "Keep all rows that satisfy:",
         },


### PR DESCRIPTION
Let me know thoughts on the specific wording of the prompt. Right now it is "Keep all rows that satisfy:"

We can also use this prompt feature for other expression editor transformers. I think Sort might benefit from it, but I'm not sure the right wording to use.