### PR TITLE
use icon for about button

### DIFF
--- a/src/components/info-components/AboutInfo.tsx
+++ b/src/components/info-components/AboutInfo.tsx
@@ -8,7 +8,15 @@ function AboutInfo(): ReactElement {
   return (
     <Popover
       button={
-        <IconButton style={{ padding: "0" }} size="medium">
+        <IconButton
+          style={{
+            padding: "0",
+            position: "fixed",
+            bottom: "15px",
+            right: "15px",
+          }}
+          size="medium"
+        >
           <HelpIcon htmlColor="var(--blue-green)" fontSize="inherit" />
         </IconButton>
       }

--- a/src/components/info-components/AboutInfo.tsx
+++ b/src/components/info-components/AboutInfo.tsx
@@ -1,11 +1,17 @@
 import React, { ReactElement } from "react";
 import Popover from "../ui-components/Popover";
 import "./styles/AboutInfo.css";
+import HelpIcon from "@material-ui/icons/Help";
+import { IconButton } from "@material-ui/core";
 
 function AboutInfo(): ReactElement {
   return (
     <Popover
-      button={<button style={{ fontSize: "11px" }}>About</button>}
+      button={
+        <IconButton style={{ padding: "0" }} size="medium">
+          <HelpIcon htmlColor="var(--blue-green)" fontSize="inherit" />
+        </IconButton>
+      }
       tooltip={`About the Transformers Plugin`}
       innerContent={
         <div id="about-info">


### PR DESCRIPTION
This tries out using an `IconButton` for the "About" button:
| Button      | IconButton |
| ----------- | ----------- |
| ![button](https://user-images.githubusercontent.com/13399527/128224097-9b467912-55c0-4b9c-bb16-dba6c7d12a9b.png) | ![about](https://user-images.githubusercontent.com/13399527/128223801-48c425b2-6cca-459a-8b8c-e5db31a7506f.png) |



I do like that this reduces the size of the button but it has the disadvantage of being quite similar to the (i) icon and right above it. Which do you all prefer?