### PR TITLE
Invalid cache on attribute rename

### DIFF
--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -262,7 +262,8 @@ function codapRequestHandler(
       // give enough information.
       if (
         value.operation === ContextChangeOperation.MoveAttribute ||
-        value.operation === ContextChangeOperation.DeleteAttribute
+        value.operation === ContextChangeOperation.DeleteAttribute ||
+        value.operation === ContextChangeOperation.UpdateAttribute
       ) {
         Cache.invalidateCasesInContext(contextName);
       }


### PR DESCRIPTION
This fixes a bug where if you do a transform on an attribute and that attribute is renamed, the update will not error because it still sees the old name for the attribute in the cache.