### PR TITLE
make partition updates synchronous

### DIFF
--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -767,12 +767,6 @@ export async function updateContextWithDataSet(
 
   const responses = await callMultiple(requests);
 
-  if (responses === undefined) {
-    throw new Error(
-      `Received no response from CODAP when updating ${contextName}`
-    );
-  }
-
   for (const response of responses) {
     if (!response.success) {
       throw new Error(`Failed to update ${contextName}`);

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -766,6 +766,13 @@ export async function updateContextWithDataSet(
   requests.push(Actions.insertDataItems(contextName, dataset.records));
 
   const responses = await callMultiple(requests);
+
+  if (responses === undefined) {
+    throw new Error(
+      `Received no response from CODAP when updating ${contextName}`
+    );
+  }
+
   for (const response of responses) {
     if (!response.success) {
       throw new Error(`Failed to update ${contextName}`);

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -269,7 +269,7 @@ async function partitionUpdateInner({
       outputContexts.push(newName);
     } else {
       // apply an update to a previous dataset
-      updateContextWithDataSet(contextName, partitioned.dataset);
+      await updateContextWithDataSet(contextName, partitioned.dataset);
 
       // copy over existing context name into new valueToContext mapping
       newValueToContext[partitioned.distinctValueAsStr] = contextName;


### PR DESCRIPTION
This fixes #95, at least for partition. However, I have no idea why. It does so by making partition updates synchronous. As a consequence this makes partition updates a lot slower.

I also threw in a more specific error if the response from CODAP comes back `undefined` in `updateContextWithDataSet`, so that we'll at least get something better than responses is not iterable.

I'm not sure what we want to do about this since I'm the only one who can reproduce. 