### PR TITLE
Flow title updates

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -199,7 +199,7 @@ const titleFromComponent = (
   return tmp && tmp.title ? <h3>{tmp.title}</h3> : <></>;
 };
 
-interface DatasetCreatorFunction {
+export interface DatasetCreatorFunction {
   kind: "datasetCreator";
   func: (state: TransformerTemplateState) => Promise<TransformationOutput>;
 }

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -211,7 +211,10 @@ export interface FullOverrideFunction {
     state: TransformerTemplateState,
     errorId: number
   ) => Promise<void>;
-  updateFunc: (state: FullOverrideSaveState) => Promise<{
+  updateFunc: (
+    state: FullOverrideSaveState,
+    editedOutputs: Set<string>
+  ) => Promise<{
     extraDependencies?: string[];
     state?: Partial<FullOverrideSaveState>;
   }>;

--- a/src/lib/codapPhone/actions.ts
+++ b/src/lib/codapPhone/actions.ts
@@ -4,12 +4,15 @@ import {
   DeleteRequest,
   CreateCollectionsRequest,
   CreateDataItemsRequest,
+  UpdateContextRequest,
+  DataContext,
 } from "./types";
 import {
   allCases,
   collectionFromContext,
   collectionOfContext,
   itemFromContext,
+  resourceFromContext,
 } from "./resource";
 
 export function deleteAllCases(
@@ -51,5 +54,16 @@ export function insertDataItems(
     action: CodapActions.Create,
     resource: itemFromContext(contextName),
     values: data,
+  };
+}
+
+export function updateDataContext(
+  context: string,
+  values: Partial<DataContext>
+): UpdateContextRequest {
+  return {
+    action: CodapActions.Update,
+    resource: resourceFromContext(context),
+    values: values,
   };
 }

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -740,7 +740,8 @@ export function insertDataItems(
 export async function updateContextWithDataSet(
   contextName: string,
   dataset: DataSet,
-  title?: string
+  title?: string,
+  metadata?: ContextMetadata
 ): Promise<void> {
   const context = await getDataContext(contextName);
   const requests = [];
@@ -782,8 +783,15 @@ export async function updateContextWithDataSet(
 
   requests.push(Actions.insertDataItems(contextName, dataset.records));
 
-  if (title !== undefined) {
-    requests.push(Actions.updateDataContext(contextName, { title }));
+  if (title !== undefined || metadata !== undefined) {
+    const toUpdate: Partial<DataContext> = {};
+    if (title !== undefined) {
+      toUpdate.title = title;
+    }
+    if (metadata !== undefined) {
+      toUpdate.metadata = metadata;
+    }
+    requests.push(Actions.updateDataContext(contextName, toUpdate));
   }
 
   const responses = await callMultiple(requests);

--- a/src/lib/codapPhone/listeners.ts
+++ b/src/lib/codapPhone/listeners.ts
@@ -217,3 +217,9 @@ export const [
   removeTextDeletedHook,
   callAllTextDeletedHooks,
 ] = makeHook();
+
+export const [
+  addOutputTitleChangeHook,
+  removeOutputTitleChangeHook,
+  callAllOutputTitleChangeHooks,
+] = makeHook();

--- a/src/lib/codapPhone/types.ts
+++ b/src/lib/codapPhone/types.ts
@@ -381,11 +381,10 @@ export type CodapInitiatedCommand =
     }
   | {
       action: CodapActions.Notify;
+
+      // Actually dataContextChangeNotice[contextName]
       resource: CodapInitiatedResource.DataContextChangeNotice;
-      values: {
-        operation: ContextChangeOperation;
-        result?: Record<string, unknown>;
-      }[];
+      values: DataContextChangeNoticeValue[];
     }
   | {
       action: CodapActions.Notify;
@@ -397,7 +396,101 @@ export type CodapInitiatedCommand =
         name: string;
         title: string;
       };
+    }
+  | TextViewTitleChangeNotification;
+
+export type DataContextChangeNoticeValue =
+  | {
+      operation: ContextChangeOperation.UpdateCases;
+      result: { success: boolean; caseIDs: number[]; cases: ReturnedCase[] };
+    }
+  | {
+      operation: ContextChangeOperation.CreateCases;
+      result: {
+        success: boolean;
+        caseID: number;
+        caseIDs: number[];
+        itemID: number;
+        itemIDs: number[];
+      };
+    }
+  | {
+      operation: ContextChangeOperation.DeleteCases;
+      result: {
+        success: boolean;
+        cases?: ReturnedCase[];
+        caseIDs?: number[];
+      };
+    }
+  | {
+      operation: ContextChangeOperation.SelectCases;
+      result: {
+        success: boolean;
+        cases: ReturnedCase[];
+        extend: boolean;
+      };
+    }
+  | {
+      operation: ContextChangeOperation.UpdateContext;
+      result: {
+        success: boolean;
+        properties: Partial<DataContext>;
+      };
+    }
+  | {
+      operation: ContextChangeOperation.MoveCases;
+      result: {
+        success: boolean;
+
+        // For some reason this is always empty
+        caseIDs: number[];
+      };
+    }
+  | {
+      operation:
+        | ContextChangeOperation.CreateAttribute
+        | ContextChangeOperation.UpdateAttribute
+        | ContextChangeOperation.MoveAttribute;
+      result: {
+        success: boolean;
+        attrs: CodapAttribute[];
+        attrIDs: number[];
+      };
+    }
+  | {
+      operation:
+        | ContextChangeOperation.DeleteAttribute
+        | ContextChangeOperation.HideAttribute
+        | ContextChangeOperation.UnhideAttribute;
+      result: { success: boolean; attrIDs: number[] };
+    }
+  | {
+      operation: ContextChangeOperation.UpdateCollection;
+      result: { success: boolean; properties: Partial<Collection> };
+    }
+  | {
+      operation: ContextChangeOperation.CreateCollection;
+      result: { success: boolean; collection: number };
+    }
+  | {
+      operation:
+        | ContextChangeOperation.DeleteCollection
+        | ContextChangeOperation.DependentCases;
+      result: { success: boolean };
     };
+
+export interface TextViewTitleChangeNotification {
+  action: CodapActions.Notify;
+
+  // Actually dataContextChangeNotice[contextName]
+  resource: CodapResource.Component;
+  type: "DG.TextView";
+  values: {
+    operation: "titleChange";
+    from: string;
+    to: string;
+  };
+}
 
 // The `metadata` property of data contexts is undocumented but described here:
 // https://codap.concord.org/forums/topic/accessing-dataset-description-through-plugin-api/

--- a/src/lib/codapPhone/types.ts
+++ b/src/lib/codapPhone/types.ts
@@ -332,6 +332,7 @@ export const mutatingOperations = [
   ContextChangeOperation.UpdateCases,
   ContextChangeOperation.CreateCases,
   ContextChangeOperation.DeleteCases,
+  ContextChangeOperation.UpdateContext,
   ContextChangeOperation.MoveCases,
   ContextChangeOperation.CreateAttribute,
   ContextChangeOperation.UpdateAttribute,

--- a/src/lib/codapPhone/util.ts
+++ b/src/lib/codapPhone/util.ts
@@ -246,3 +246,7 @@ export function parseEvalError(message: string): string {
     return message;
   }
 }
+
+export function parseNameBetweenBrackets(text: string): string {
+  return text.slice(text.indexOf("[") + 1, text.indexOf("]"));
+}

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -45,6 +45,7 @@ export type TransformersInteractiveState = {
     description: string;
   };
   activeTransformations?: TransformationDescription[];
+  editedOutputs?: string[];
 };
 
 export type TransformerGroup =

--- a/src/transformerStore/util.ts
+++ b/src/transformerStore/util.ts
@@ -56,7 +56,6 @@ export async function updateFromDescription(
   if (transformFunc.kind === "datasetCreator") {
     description = description as DatasetCreatorDescription;
     if (description.outputType === TransformationOutputType.CONTEXT) {
-      console.log("Edited outputs: " + [...editedOutputs]);
       await updateContextFromDatasetCreator(
         description.state,
         description.output,
@@ -81,7 +80,7 @@ export async function updateFromDescription(
     }
   } else if (transformFunc.kind === "fullOverride") {
     description = description as FullOverrideDescription;
-    await updateFromFullOverride(description, dispatch);
+    await updateFromFullOverride(description, dispatch, editedOutputs);
   }
 }
 
@@ -110,7 +109,6 @@ async function updateTextFromDatasetCreator(
   ) => Promise<SingleValueTransformationOutput>,
   updateTitle: boolean
 ): Promise<void> {
-  console.log("updateTitle is " + updateTitle);
   const [result, newTitle] = await transformFunc(state);
   await updateText(
     outputName,
@@ -121,12 +119,13 @@ async function updateTextFromDatasetCreator(
 
 async function updateFromFullOverride(
   description: FullOverrideDescription,
-  dispatch: React.Dispatch<ActiveTransformationsAction>
+  dispatch: React.Dispatch<ActiveTransformationsAction>,
+  editedOutputs: Set<string>
 ) {
   const newState = await (
     transformerList[description.transformer].componentData
       .transformerFunction as FullOverrideFunction
-  ).updateFunc(description.state);
+  ).updateFunc(description.state, editedOutputs);
   dispatch({
     type: ActionTypes.EDIT,
     transformation: description,

--- a/src/transformerStore/util.ts
+++ b/src/transformerStore/util.ts
@@ -92,13 +92,15 @@ async function updateContextFromDatasetCreator(
   ) => Promise<DataSetTransformationOutput>,
   updateTitle: boolean
 ): Promise<void> {
-  const [transformed, newTitle] = await transformFunc(state);
+  const [transformed, newTitle, newDescription] = await transformFunc(state);
   const immutableTransformed = makeDatasetImmutable(transformed);
-  await updateContextWithDataSet(
-    outputName,
-    immutableTransformed,
-    updateTitle ? newTitle : undefined
-  );
+  if (updateTitle) {
+    await updateContextWithDataSet(outputName, immutableTransformed, newTitle, {
+      description: newDescription,
+    });
+  } else {
+    await updateContextWithDataSet(outputName, immutableTransformed);
+  }
 }
 
 async function updateTextFromDatasetCreator(

--- a/src/transformers/partition.ts
+++ b/src/transformers/partition.ts
@@ -278,11 +278,17 @@ async function partitionUpdateInner(
       const updateTitle = !editedOutputs.has(contextName);
 
       // apply an update to a previous dataset
-      updateContextWithDataSet(
-        contextName,
-        partitioned.dataset,
-        updateTitle ? name : undefined
-      );
+      if (updateTitle) {
+        updateContextWithDataSet(contextName, partitioned.dataset, name, {
+          description: partitionDatasetDescription(
+            partitioned,
+            inputDataCtxtName,
+            attributeName
+          ),
+        });
+      } else {
+        updateContextWithDataSet(contextName, partitioned.dataset);
+      }
 
       // copy over existing context name into new valueToContext mapping
       newValueToContext[partitioned.distinctValueAsStr] = contextName;

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -21,7 +21,10 @@ import {
 } from "../lib/codapPhone/listeners";
 import { InteractiveState } from "../lib/codapPhone/types";
 import AboutInfo from "../components/info-components/AboutInfo";
-import { useActiveTransformations } from "../transformerStore";
+import {
+  useActiveTransformations,
+  useEditedOutputs,
+} from "../transformerStore";
 import { ActionTypes } from "../transformerStore/types";
 import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
@@ -71,9 +74,11 @@ function REPLView(): ReactElement {
   const [errorStore, setErrMsg] = useErrorStore();
   const errorId = useErrorSetterId();
 
+  const [editedOutputs, addEditedOutput, setEditedOutputs] = useEditedOutputs();
+
   // activeTransformations (first element of tuple) can be used to draw a diagram
   const [, activeTransformationsDispatch, wrappedDispatch] =
-    useActiveTransformations(setErrMsg);
+    useActiveTransformations(setErrMsg, editedOutputs, addEditedOutput);
 
   function transformerChangeHandler(
     selected: ValueType<{ value: BaseTransformerName; label: string }, false>,
@@ -104,9 +109,12 @@ function REPLView(): ReactElement {
           ),
         });
       }
+      if (savedState.editedOutputs !== undefined) {
+        setEditedOutputs(new Set(savedState.editedOutputs));
+      }
     }
     fetchSavedState();
-  }, [activeTransformationsDispatch]);
+  }, [activeTransformationsDispatch, setEditedOutputs]);
 
   // Register a listener to generate the plugins state
   useEffect(() => {

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -20,7 +20,10 @@ import {
 } from "../lib/codapPhone/listeners";
 import "../components/transformer-template/styles/DefinitionCreator.css";
 import "./styles/SavedDefinitionView.css";
-import { useActiveTransformations } from "../transformerStore";
+import {
+  useActiveTransformations,
+  useEditedOutputs,
+} from "../transformerStore";
 import { ActionTypes } from "../transformerStore/types";
 import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
@@ -40,8 +43,9 @@ function SavedDefinitionView({
   const [editable, setEditable] = useState<boolean>(false);
   const [savedTransformer, setSavedTransformer] = useState(urlTransformer);
   const [saveErr, setSaveErr] = useState<string | null>(null);
+  const [editedOutputs, addEditedOutput, setEditedOutputs] = useEditedOutputs();
   const [, activeTransformationsDispatch, wrappedDispatch] =
-    useActiveTransformations(setErrMsg);
+    useActiveTransformations(setErrMsg, editedOutputs, addEditedOutput);
 
   // Load saved state from CODAP memory
   useEffect(() => {
@@ -65,11 +69,14 @@ function SavedDefinitionView({
           ),
         });
       }
+      if (savedState.editedOutputs !== undefined) {
+        setEditedOutputs(new Set(savedState.editedOutputs));
+      }
     }
     fetchSavedState();
 
     // Identity of dispatch is stable since it came from useReducer
-  }, [activeTransformationsDispatch, savedTransformer]);
+  }, [activeTransformationsDispatch, savedTransformer, setEditedOutputs]);
 
   // Register a listener to generate the plugin's state
   useEffect(() => {


### PR DESCRIPTION
Add `useEditedOutputs`, which keeps track of the contexts that have had their titles manually edited, and use this information to decide whether to include updated titles in normal transformer updates.