### PR TITLE
Disable CODAP close button and add custom close button

### DIFF
--- a/src/components/info-components/AboutInfo.tsx
+++ b/src/components/info-components/AboutInfo.tsx
@@ -11,9 +11,7 @@ function AboutInfo(): ReactElement {
         <IconButton
           style={{
             padding: "0",
-            position: "fixed",
-            bottom: "15px",
-            right: "15px",
+            marginLeft: "auto",
           }}
           size="medium"
         >

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -100,6 +100,7 @@ export async function initPhone(title: string, saved: boolean): Promise<void> {
     // Don't update the title if there is save data.
     title: hasState ? undefined : title,
     dimensions,
+    cannotClose: true,
   });
 }
 

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -454,6 +454,29 @@ export function updateComponent(
     )
   );
 }
+
+export function deleteComponent(component: string): Promise<void> {
+  return new Promise((resolve, reject) =>
+    phone.call(
+      {
+        action: CodapActions.Delete,
+        resource: resourceFromComponent(component),
+      },
+      (response) => {
+        if (response) {
+          if (response.success) {
+            resolve();
+          } else {
+            reject(new Error("Failed to delete component"));
+          }
+        } else {
+          reject(new Error("Invalid response while deleting component"));
+        }
+      }
+    )
+  );
+}
+
 export function updateDataContext(
   context: string,
   values: Partial<DataContext>

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -156,6 +156,7 @@ function REPLView(): ReactElement {
             }}
             size="medium"
             onClick={() => closePlugin(activeTransformations)}
+            title="Close plugin"
           >
             <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
           </IconButton>

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -28,6 +28,7 @@ import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
 import Select, { ValueType, ActionMeta } from "react-select";
 import TransformerInfo from "../components/info-components/TransformerInfo";
+import { closePlugin } from "./util";
 
 // These are the base transformer types represented as SavedTransformer
 // objects
@@ -137,18 +138,6 @@ function REPLView(): ReactElement {
     notifyInteractiveFrameIsDirty();
   }
 
-  async function closePlugin() {
-    if (
-      Object.keys(activeTransformations).length === 0 ||
-      confirm(
-        `Closing the transformers plugin will stop transformed datasets from updating. Are you sure you'd like to proceed?`
-      )
-    ) {
-      const id = (await getInteractiveFrame()).id;
-      deleteComponent(id.toString());
-    }
-  }
-
   // Tutorial info about the current transformer
   const info = transformType
     ? transformerList[transformType].componentData.info
@@ -158,7 +147,10 @@ function REPLView(): ReactElement {
     <div className="transformer-view">
       <div className="title-row">
         <h3>Transformer</h3>
-        <button style={{ marginLeft: "auto" }} onClick={closePlugin}>
+        <button
+          style={{ marginLeft: "auto" }}
+          onClick={() => closePlugin(activeTransformations)}
+        >
           Close Plugin
         </button>
         <AboutInfo />

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -12,7 +12,6 @@ import transformerList, {
   TransformerGroup,
 } from "../transformerList";
 import {
-  deleteComponent,
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
 } from "../lib/codapPhone";
@@ -29,6 +28,8 @@ import { TransformerRenderer } from "../components/transformer-template/Transfor
 import Select, { ValueType, ActionMeta } from "react-select";
 import TransformerInfo from "../components/info-components/TransformerInfo";
 import { closePlugin } from "./util";
+import { Cancel } from "@material-ui/icons";
+import { IconButton } from "@material-ui/core";
 
 // These are the base transformer types represented as SavedTransformer
 // objects
@@ -147,12 +148,16 @@ function REPLView(): ReactElement {
     <div className="transformer-view">
       <div className="title-row">
         <h3>Transformer</h3>
-        <button
-          style={{ marginLeft: "auto" }}
+        <IconButton
+          style={{
+            padding: "0",
+            marginLeft: "auto",
+          }}
+          size="medium"
           onClick={() => closePlugin(activeTransformations)}
         >
-          Close Plugin
-        </button>
+          <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
+        </IconButton>
         <AboutInfo />
       </div>
 

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -12,6 +12,7 @@ import transformerList, {
   TransformerGroup,
 } from "../transformerList";
 import {
+  deleteComponent,
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
 } from "../lib/codapPhone";
@@ -72,8 +73,11 @@ function REPLView(): ReactElement {
   const errorId = useErrorSetterId();
 
   // activeTransformations (first element of tuple) can be used to draw a diagram
-  const [, activeTransformationsDispatch, wrappedDispatch] =
-    useActiveTransformations(setErrMsg);
+  const [
+    activeTransformations,
+    activeTransformationsDispatch,
+    wrappedDispatch,
+  ] = useActiveTransformations(setErrMsg);
 
   function transformerChangeHandler(
     selected: ValueType<{ value: BaseTransformerName; label: string }, false>,
@@ -133,6 +137,18 @@ function REPLView(): ReactElement {
     notifyInteractiveFrameIsDirty();
   }
 
+  async function closePlugin() {
+    if (
+      Object.keys(activeTransformations).length === 0 ||
+      confirm(
+        `Closing the transformers plugin will stop transformed datasets from updating. Are you sure you'd like to proceed?`
+      )
+    ) {
+      const id = (await getInteractiveFrame()).id;
+      deleteComponent(id.toString());
+    }
+  }
+
   // Tutorial info about the current transformer
   const info = transformType
     ? transformerList[transformType].componentData.info
@@ -142,7 +158,9 @@ function REPLView(): ReactElement {
     <div className="transformer-view">
       <div className="title-row">
         <h3>Transformer</h3>
-
+        <button style={{ marginLeft: "auto" }} onClick={closePlugin}>
+          Close Plugin
+        </button>
         <AboutInfo />
       </div>
 

--- a/src/views/REPLView.tsx
+++ b/src/views/REPLView.tsx
@@ -148,17 +148,18 @@ function REPLView(): ReactElement {
     <div className="transformer-view">
       <div className="title-row">
         <h3>Transformer</h3>
-        <IconButton
-          style={{
-            padding: "0",
-            marginLeft: "auto",
-          }}
-          size="medium"
-          onClick={() => closePlugin(activeTransformations)}
-        >
-          <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
-        </IconButton>
-        <AboutInfo />
+        <div>
+          <AboutInfo />
+          <IconButton
+            style={{
+              padding: "0",
+            }}
+            size="medium"
+            onClick={() => closePlugin(activeTransformations)}
+          >
+            <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
+          </IconButton>
+        </div>
       </div>
 
       <div className="select-row">

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -130,6 +130,7 @@ function SavedDefinitionView({
             }}
             size="medium"
             onClick={() => closePlugin(activeTransformations)}
+            title="Close definition"
           >
             <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
           </IconButton>

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -24,6 +24,7 @@ import { useActiveTransformations } from "../transformerStore";
 import { ActionTypes } from "../transformerStore/types";
 import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
+import { closePlugin } from "./util";
 
 /**
  * SavedDefinitionView wraps a saved transformer in other important info
@@ -40,8 +41,11 @@ function SavedDefinitionView({
   const [editable, setEditable] = useState<boolean>(false);
   const [savedTransformer, setSavedTransformer] = useState(urlTransformer);
   const [saveErr, setSaveErr] = useState<string | null>(null);
-  const [, activeTransformationsDispatch, wrappedDispatch] =
-    useActiveTransformations(setErrMsg);
+  const [
+    activeTransformations,
+    activeTransformationsDispatch,
+    wrappedDispatch,
+  ] = useActiveTransformations(setErrMsg);
 
   // Load saved state from CODAP memory
   useEffect(() => {
@@ -112,10 +116,18 @@ function SavedDefinitionView({
           onBlur={notifyStateIsDirty}
         />
       ) : (
-        <h2>
-          {savedTransformer.name}
-          <span id="transformerBase"> ({savedTransformer.content.base})</span>
-        </h2>
+        <div className="title-row">
+          <h2>
+            {savedTransformer.name}
+            <span id="transformerBase"> ({savedTransformer.content.base})</span>
+          </h2>
+          <button
+            style={{ marginLeft: "auto" }}
+            onClick={() => closePlugin(activeTransformations)}
+          >
+            Close Plugin
+          </button>
+        </div>
       )}
       {editable ? (
         <>

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -25,6 +25,8 @@ import { ActionTypes } from "../transformerStore/types";
 import { deserializeActiveTransformations } from "../transformerStore/util";
 import { TransformerRenderer } from "../components/transformer-template/TransformerRenderer";
 import { closePlugin } from "./util";
+import { IconButton } from "@material-ui/core";
+import { Cancel } from "@material-ui/icons";
 
 /**
  * SavedDefinitionView wraps a saved transformer in other important info
@@ -121,12 +123,16 @@ function SavedDefinitionView({
             {savedTransformer.name}
             <span id="transformerBase"> ({savedTransformer.content.base})</span>
           </h2>
-          <button
-            style={{ marginLeft: "auto" }}
+          <IconButton
+            style={{
+              padding: "0",
+              marginLeft: "auto",
+            }}
+            size="medium"
             onClick={() => closePlugin(activeTransformations)}
           >
-            Close Plugin
-          </button>
+            <Cancel htmlColor="var(--blue-green)" fontSize="inherit" />
+          </IconButton>
         </div>
       )}
       {editable ? (

--- a/src/views/styles/SavedDefinitionView.css
+++ b/src/views/styles/SavedDefinitionView.css
@@ -20,3 +20,9 @@
 .divider {
     margin-top: 10px;
 }
+
+.title-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}

--- a/src/views/util.ts
+++ b/src/views/util.ts
@@ -5,7 +5,8 @@ export async function closePlugin(
   activeTransformations: Record<string, TransformationDescription[]>
 ): Promise<void> {
   if (
-    Object.keys(activeTransformations).length === 0 ||
+    // If there aren't any active transformers then we don't need to confirm
+    Object.values(activeTransformations).some((a) => a.length > 0) ||
     confirm(
       `Closing the transformers plugin will stop transformed datasets from updating. Are you sure you'd like to proceed?`
     )

--- a/src/views/util.ts
+++ b/src/views/util.ts
@@ -6,7 +6,8 @@ export async function closePlugin(
 ): Promise<void> {
   if (
     // If there aren't any active transformers then we don't need to confirm
-    Object.values(activeTransformations).some((a) => a.length > 0) ||
+    Object.keys(activeTransformations).length === 0 ||
+    !Object.values(activeTransformations).some((a) => a.length > 0) ||
     confirm(
       `Closing the transformers plugin will stop transformed datasets from updating. Are you sure you'd like to proceed?`
     )

--- a/src/views/util.ts
+++ b/src/views/util.ts
@@ -1,0 +1,16 @@
+import { deleteComponent, getInteractiveFrame } from "../lib/codapPhone";
+import { TransformationDescription } from "../transformerStore/types";
+
+export async function closePlugin(
+  activeTransformations: Record<string, TransformationDescription[]>
+): Promise<void> {
+  if (
+    Object.keys(activeTransformations).length === 0 ||
+    confirm(
+      `Closing the transformers plugin will stop transformed datasets from updating. Are you sure you'd like to proceed?`
+    )
+  ) {
+    const id = (await getInteractiveFrame()).id;
+    deleteComponent(id.toString());
+  }
+}


### PR DESCRIPTION
This PR disables the CODAP close button for the plugin component and adds a custom close button that asks the user to confirm if they close the plugin while there are any `activeTransformations`. This also applies to saved transformers