### PR TITLE
Capitalize type names in contracts

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -146,8 +146,8 @@ const DEFAULT_STATE: TransformerTemplateState = {
   dropdown2: null,
   expression1: "",
   expression2: "",
-  typeContract1: { inputType: "any", outputType: "any" },
-  typeContract2: { inputType: "any", outputType: "any" },
+  typeContract1: { inputType: "Any", outputType: "Any" },
+  typeContract2: { inputType: "Any", outputType: "Any" },
 };
 
 const contextFromCollection = (

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -76,7 +76,7 @@ interface ExpressionInit extends ComponentInit {}
 interface TypeContractInit extends ComponentInit {
   inputTypes: string[] | string;
   inputTypeDisabled?: boolean;
-  outputTypes: string[] | string;
+  outputTypes: readonly string[] | string;
   outputTypeDisabled?: boolean;
 }
 export type TransformerTemplateInit = {

--- a/src/components/ui-components/TypeSelector.tsx
+++ b/src/components/ui-components/TypeSelector.tsx
@@ -6,7 +6,7 @@ interface TypeSelectorProps {
   selectedInputType: string;
   inputTypeOnChange?: React.ChangeEventHandler<HTMLSelectElement>;
   inputTypeDisabled?: boolean;
-  outputTypes: string[] | string;
+  outputTypes: readonly string[] | string;
   selectedOutputType: string;
   outputTypeOnChange?: React.ChangeEventHandler<HTMLSelectElement>;
   outputTypeDisabled?: boolean;

--- a/src/lib/utils/typeChecking.ts
+++ b/src/lib/utils/typeChecking.ts
@@ -52,28 +52,28 @@ export async function findTypeErrors(
   ) => Promise<unknown[]>
 ): Promise<number[]> {
   switch (type) {
-    case "any":
+    case "Any":
       // All values are allowed for any, so we can return immediately
       return [];
-    case "number":
+    case "Number":
       return checkTypeOfValues(
         CodapTypePredicateFunctions.Number,
         values,
         evalFormula
       );
-    case "string":
+    case "String":
       return checkTypeOfValues(
         CodapTypePredicateFunctions.String,
         values,
         evalFormula
       );
-    case "boolean":
+    case "Boolean":
       return checkTypeOfValues(
         CodapTypePredicateFunctions.Boolean,
         values,
         evalFormula
       );
-    case "boundary":
+    case "Boundary":
       return checkTypeOfValues(
         CodapTypePredicateFunctions.Boundary,
         values,

--- a/src/strings/en/errors.ts
+++ b/src/strings/en/errors.ts
@@ -75,7 +75,7 @@ const errors = {
   filter: {
     noExpression: "Please enter an expression by which to filter",
     nonBooleanResult:
-      "Please enter an expression that evaluates to a boolean. The one you entered evaluated to {{ value }} for case {{ caseNumber }}",
+      "Please enter an expression that evaluates to a Boolean. The one you entered evaluated to {{ value }} for case {{ caseNumber }}",
   },
   join: {
     noDataSetOrAttribute: "Please choose two datasets and two attributes",

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -34,6 +34,7 @@ import { partitionOverride, partitionUpdate } from "./transformers/partition";
 import { editableCopyOverride } from "./transformers/editableCopy";
 import { transformAttribute } from "./transformers/transformAttribute";
 import { compare } from "./transformers/compare";
+import { codapLanguageTypes } from "./transformers/types";
 
 export type TransformersInteractiveState = {
   transformerREPL?: {
@@ -124,9 +125,6 @@ function docLinkFromHeadingID(headingID: string): string {
   return `https://docs.google.com/document/d/1NZA9gxtu6jD3M-5SQyx0tvV2N5qYKMgRm1XUwMnLgJU/edit#heading=${headingID}`;
 }
 
-// All possible types, used in user-configurable contracts.
-const allTypes = ["Any", "String", "Number", "Boolean", "Boundary"];
-
 const transformerList: TransformerList = {
   "Build Attribute": {
     group: "Constructing",
@@ -144,7 +142,7 @@ const transformerList: TransformerList = {
         typeContract1: {
           title: "Formula for Attribute Values",
           inputTypes: "Row",
-          outputTypes: allTypes,
+          outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },
@@ -180,7 +178,7 @@ const transformerList: TransformerList = {
         typeContract1: {
           title: "Formula for Transformed Values",
           inputTypes: "Row",
-          outputTypes: allTypes,
+          outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },
@@ -268,7 +266,7 @@ const transformerList: TransformerList = {
         typeContract1: {
           title: "Key expression",
           inputTypes: "Row",
-          outputTypes: allTypes,
+          outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -124,6 +124,9 @@ function docLinkFromHeadingID(headingID: string): string {
   return `https://docs.google.com/document/d/1NZA9gxtu6jD3M-5SQyx0tvV2N5qYKMgRm1XUwMnLgJU/edit#heading=${headingID}`;
 }
 
+// All possible types, used in user-configurable contracts.
+const allTypes = ["Any", "String", "Number", "Boolean", "Boundary"];
+
 const transformerList: TransformerList = {
   "Build Attribute": {
     group: "Constructing",
@@ -140,8 +143,8 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Formula for Attribute Values",
-          inputTypes: "row",
-          outputTypes: ["any", "string", "number", "boolean", "boundary"],
+          inputTypes: "Row",
+          outputTypes: allTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },
@@ -176,8 +179,8 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Formula for Transformed Values",
-          inputTypes: "row",
-          outputTypes: ["any", "string", "number", "boolean", "boundary"],
+          inputTypes: "Row",
+          outputTypes: allTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },
@@ -207,8 +210,8 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "How to Filter",
-          inputTypes: "row",
-          outputTypes: "boolean",
+          inputTypes: "Row",
+          outputTypes: "Boolean",
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
@@ -264,8 +267,8 @@ const transformerList: TransformerList = {
         },
         typeContract1: {
           title: "Key expression",
-          inputTypes: "row",
-          outputTypes: ["any", "string", "number", "boolean", "boundary"],
+          inputTypes: "Row",
+          outputTypes: allTypes,
           inputTypeDisabled: true,
         },
         expression1: { title: "" },

--- a/src/transformers/__tests__/buildAttribute.test.ts
+++ b/src/transformers/__tests__/buildAttribute.test.ts
@@ -40,7 +40,7 @@ test("throws error when non-existent collection given", () => {
     "New Col",
     "not here",
     "C + 1",
-    "number"
+    "Number"
   ).catch((e) => expect(e.message).toMatch(/was not found/));
 });
 
@@ -51,7 +51,7 @@ test("throws error when new attribute collides with existing", () => {
     "A",
     "child",
     "C + 1",
-    "number"
+    "Number"
   ).catch((e) => expect(e.message).toMatch(/already in use/));
 });
 
@@ -62,7 +62,7 @@ test("throws error when expression uses unbound values", async () => {
       "E",
       "child",
       "AttributeNameThatDoesntExist + 1",
-      "any",
+      "Any",
       jsEvalExpression
     );
   } catch (e) {
@@ -78,7 +78,7 @@ test("using attribute name as formula creates clone of attribute", async () => {
         "D",
         "child",
         "C",
-        "any",
+        "Any",
         jsEvalExpression
       )
     ).records.map((row) => row.D)
@@ -98,7 +98,7 @@ test("build attribute does nothing to dataset with no records", async () => {
       "G",
       "Collection A",
       "A + B * F + 1",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(COLLECTION_A_OUTPUT);
@@ -115,7 +115,7 @@ test("build attribute does nothing to dataset with no records", async () => {
       "G",
       "Collection B",
       "A + B * F + 1",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(COLLECTION_B_OUTPUT);
@@ -132,7 +132,7 @@ test("build attribute does nothing to dataset with no records", async () => {
       "G",
       "Collection C",
       "A + B * F + 1",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(COLLECTION_C_OUTPUT);
@@ -155,7 +155,7 @@ test("using attribute name as formula creates clone of attribute", async () => {
       "BirthYear",
       "people",
       "Year - Age",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(CENSUS_DATASET_OUTPUT);
@@ -174,7 +174,7 @@ test("all attribute metadata is copied", async () => {
       "D",
       "Collection",
       '""',
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(OUTPUT);

--- a/src/transformers/__tests__/filter.test.ts
+++ b/src/transformers/__tests__/filter.test.ts
@@ -119,7 +119,7 @@ test("all attribute metadata is copied", async () => {
 });
 
 test("errors when predicate evaluates to non-boolean", async () => {
-  const nonBooleanErr = /evaluates to a boolean/;
+  const nonBooleanErr = /evaluates to a Boolean/;
   expect.assertions(5);
 
   try {

--- a/src/transformers/__tests__/sort.test.ts
+++ b/src/transformers/__tests__/sort.test.ts
@@ -39,7 +39,7 @@ test("no change to dataset with no records", async () => {
     await uncheckedSortWrapper(
       EMPTY_RECORDS,
       "A",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -57,7 +57,7 @@ test("sorts numbers", async () => {
     await uncheckedSortWrapper(
       DATASET_A,
       "A",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -73,7 +73,7 @@ test("sorts numbers", async () => {
     await uncheckedSortWrapper(
       DATASET_A,
       "A",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     )
@@ -97,7 +97,7 @@ test("sorts booleans", async () => {
     await uncheckedSortWrapper(
       DATASET_A,
       "B",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     )
@@ -119,7 +119,7 @@ test("sorts booleans", async () => {
     await uncheckedSortWrapper(
       DATASET_A,
       "B",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -146,7 +146,7 @@ test("sorts strings", async () => {
     await uncheckedSortWrapper(
       DATASET_B,
       "Name",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -161,7 +161,7 @@ test("sorts strings", async () => {
     await uncheckedSortWrapper(
       DATASET_B,
       "Name",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     )
@@ -191,7 +191,7 @@ test("sorts objects", async () => {
     await uncheckedSortWrapper(
       withObjects,
       "Boundaries",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -205,7 +205,7 @@ test("sorts objects", async () => {
     await uncheckedSortWrapper(
       withObjects,
       "Boundaries",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     )
@@ -216,7 +216,7 @@ test("sorts objects", async () => {
     await uncheckedSortWrapper(
       TYPES_DATASET,
       "Boundary",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )
@@ -225,7 +225,7 @@ test("sorts objects", async () => {
     await uncheckedSortWrapper(
       TYPES_DATASET,
       "Boundary",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     )
@@ -238,7 +238,7 @@ test("errors when key expression evaluates to multiple types", async () => {
     await uncheckedSortWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_3",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     );
@@ -250,7 +250,7 @@ test("errors when key expression evaluates to multiple types", async () => {
     await uncheckedSortWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_5",
-      "any",
+      "Any",
       "descending",
       jsEvalExpression
     );
@@ -279,7 +279,7 @@ test("sort is stable", async () => {
     await uncheckedSortWrapper(
       dataset,
       "Number",
-      "any",
+      "Any",
       "ascending",
       jsEvalExpression
     )

--- a/src/transformers/__tests__/transformAttribute.test.ts
+++ b/src/transformers/__tests__/transformAttribute.test.ts
@@ -61,7 +61,7 @@ test("simple transform to constant", async () => {
       DATASET_A,
       "B",
       "10",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(transformedA);
@@ -77,7 +77,7 @@ test("transform with formula dependent on transformed attribute", async () => {
       DATASET_B,
       "Birth_Year",
       "Birth_Year + 1",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(transformedB);
@@ -95,7 +95,7 @@ test("transform with formula dependent on other attribute", async () => {
       CENSUS_DATASET,
       "sample",
       "Age > 30",
-      "any",
+      "Any",
       jsEvalExpression
     )
   ).toEqual(transformedCensus);
@@ -110,7 +110,7 @@ test("errors on invalid attribute", async () => {
       CENSUS_DATASET,
       "Unknown",
       "Year * 2",
-      "number",
+      "Number",
       jsEvalExpression
     );
   } catch (e) {
@@ -122,7 +122,7 @@ test("errors on invalid attribute", async () => {
       DATASET_A,
       "Z",
       "A + C",
-      "number",
+      "Number",
       jsEvalExpression
     );
   } catch (e) {
@@ -133,7 +133,7 @@ test("errors on invalid attribute", async () => {
       EMPTY_DATASET,
       "Anything",
       "0",
-      "number",
+      "Number",
       jsEvalExpression
     );
   } catch (e) {
@@ -150,7 +150,7 @@ test("metadata (besides formula/description of transformed attr) is copied", asy
       DATASET_WITH_META,
       "C",
       "true",
-      "boolean",
+      "Boolean",
       jsEvalExpression
     )
   ).toEqual(transformedMeta);

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -12,11 +12,11 @@ export type DataSet = {
 };
 
 export type CodapLanguageType =
-  | "string"
-  | "any"
-  | "number"
-  | "boolean"
-  | "boundary";
+  | "Any"
+  | "String"
+  | "Number"
+  | "Boolean"
+  | "Boundary";
 
 /**
  * The properties of a CODAP boundary value that are necessary for

--- a/src/transformers/types.ts
+++ b/src/transformers/types.ts
@@ -11,12 +11,14 @@ export type DataSet = {
   editable?: boolean;
 };
 
-export type CodapLanguageType =
-  | "Any"
-  | "String"
-  | "Number"
-  | "Boolean"
-  | "Boundary";
+export const codapLanguageTypes = [
+  "Any",
+  "String",
+  "Number",
+  "Boolean",
+  "Boundary",
+] as const;
+export type CodapLanguageType = typeof codapLanguageTypes[number];
 
 /**
  * The properties of a CODAP boundary value that are necessary for


### PR DESCRIPTION
Fixes #223. 

Worth noting that one reason we may have stuck with lowercase types is that it matches the uses of type names in the CODAP language (see functions `number()` or `boolean()` for instance).