### PR TITLE
rename 'formula expression' to 'expression'

### DIFF
--- a/src/components/ui-components/ExpressionEditor.tsx
+++ b/src/components/ui-components/ExpressionEditor.tsx
@@ -170,7 +170,7 @@ export default function ExpressionEditor({
             hint: codapFormulaHints,
           },
           readOnly: disabled,
-          placeholder: "Formula expression",
+          placeholder: "Expression",
         }}
         onInputRead={(editor) => {
           editor.showHint();


### PR DESCRIPTION
Fixes #226.

I figure we should hold off on changing "key expression" until we've resolved the question of sort sorting by an expression or by an attribute.