### PR TITLE
Name purpose UI

### DIFF
--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -4,9 +4,6 @@ import { SavedTransformerContent, TransformerSaveData } from "./types";
 import { createDataInteractive } from "../../lib/codapPhone";
 import "./styles/DefinitionCreator.css";
 import ErrorDisplay from "../ui-components/Error";
-import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
-import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp";
-import { IconButton } from "@material-ui/core";
 
 interface DefinitionCreatorProps {
   generateSaveData: () => TransformerSaveData;
@@ -20,7 +17,6 @@ export default function DefinitionCreator({
   disabled,
 }: DefinitionCreatorProps): ReactElement {
   const [saveErr, setSaveErr] = useState<string | null>(null);
-  const [saveUIShown, setSaveUIShown] = useState<boolean>(false);
 
   function saveTransformer(data: TransformerSaveData) {
     const { name, description } = data;
@@ -44,41 +40,12 @@ export default function DefinitionCreator({
     savedUrl.searchParams.append("transform", encoded);
 
     createDataInteractive(name, savedUrl.toString());
-
-    // clear save inputs after successful save
-    setSaveUIShown(false);
-  }
-
-  function toggleSaveUI(): void {
-    setSaveUIShown(!saveUIShown);
-    setSaveErr(null);
   }
 
   return (
     <div style={{ marginTop: "5px" }}>
-      <hr style={{ marginTop: "15px" }} />
       <div className="input-group">
-        <h3>
-          Save This Transformer
-          <IconButton
-            style={{
-              marginLeft: "5px",
-              padding: "0",
-              background: "var(--blue-green)",
-              color: "white",
-            }}
-            size="small"
-            onClick={toggleSaveUI}
-          >
-            {saveUIShown ? (
-              <ArrowDropUpIcon fontSize="inherit" />
-            ) : (
-              <ArrowDropDownIcon fontSize="inherit" />
-            )}
-          </IconButton>
-        </h3>
         <div
-          hidden={!saveUIShown}
           style={{
             marginTop: "2px",
           }}
@@ -90,7 +57,7 @@ export default function DefinitionCreator({
             }}
             className="save-transformer-button"
           >
-            Save
+            Save Transformer
           </button>
           <ErrorDisplay
             setErrMsg={(err, _id) => setSaveErr(err)}

--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -19,7 +19,7 @@ export default function DefinitionCreator({
   const [saveErr, setSaveErr] = useState<string | null>(null);
 
   function saveTransformer(data: TransformerSaveData) {
-    const { name, description } = data;
+    const { name, purposeStatement } = data;
 
     if (name.trim() === "") {
       setSaveErr("Please give the transformer a name before saving.");
@@ -33,7 +33,7 @@ export default function DefinitionCreator({
       data,
     } as SavedTransformerContent;
 
-    const savedTransformer = { name, description, content };
+    const savedTransformer = { name, purposeStatement, content };
     const encoded = encodeURIComponent(JSON.stringify(savedTransformer));
 
     const savedUrl = new URL(window.location.toString());

--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from "react";
 import { BaseTransformerName } from "../../transformerList";
 import { SavedTransformerContent, TransformerSaveData } from "./types";
-import { createDataInteractive } from "../../lib/codapPhone";
+import { createDataInteractive, getAllComponents } from "../../lib/codapPhone";
 import "./styles/DefinitionCreator.css";
 import ErrorDisplay from "../ui-components/Error";
 
@@ -18,11 +18,21 @@ export default function DefinitionCreator({
 }: DefinitionCreatorProps): ReactElement {
   const [saveErr, setSaveErr] = useState<string | null>(null);
 
-  function saveTransformer(data: TransformerSaveData) {
-    const { name, purposeStatement } = data;
+  async function saveTransformer(data: TransformerSaveData) {
+    let { name, purposeStatement } = data;
 
-    if (name.trim() === "") {
+    name = name.trim();
+
+    if (name === "") {
       setSaveErr("Please give the transformer a name before saving.");
+      return;
+    }
+
+    // Make sure a transformer with this name doesn't exist already
+    const components = await getAllComponents();
+    const full_name = `Transformer: ${name}`;
+    if (components.find((c) => c.title === full_name)) {
+      setSaveErr("A transformer with that name already exists");
       return;
     }
 

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -648,20 +648,19 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
           );
         } else if (component === "description") {
           return (
-            saveData === undefined && (
-              <div className="input-group">
-                <h3>Purpose Statement</h3>
-                <TextArea
-                  value={state.description}
-                  onChange={(e) => {
-                    setState({ description: e.target.value });
-                  }}
-                  placeholder="Purpose Statement"
-                  className="purpose-statement"
-                  onBlur={notifyStateIsDirty}
-                />
-              </div>
-            )
+            <div className="input-group">
+              <h3>Purpose Statement</h3>
+              <TextArea
+                value={state.description}
+                onChange={(e) => {
+                  setState({ description: e.target.value });
+                }}
+                placeholder="Purpose Statement"
+                className="purpose-statement"
+                onBlur={notifyStateIsDirty}
+                disabled={!editable}
+              />
+            </div>
           );
         } else {
           return "UNRECOGNIZED COMPONENT";

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -80,6 +80,9 @@ interface ToggleDropdownInit extends ComponentInit {
     }
   >;
 }
+interface NameInit extends ComponentInit {
+  placeholder?: string;
+}
 interface ExpressionInit extends ComponentInit {}
 interface TypeContractInit extends ComponentInit {
   inputTypes: string[] | string;
@@ -92,6 +95,7 @@ interface PurposeStatementInit {
 }
 export type TransformerTemplateInit = {
   toggle?: ToggleDropdownInit;
+  name?: NameInit;
   context1?: ContextInit;
   context2?: ContextInit;
   collection1?: CollectionInit;
@@ -480,20 +484,6 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
 
   return (
     <>
-      {saveData === undefined && (
-        <div className="input-group">
-          <h3>Transformer Name</h3>
-          <TextInput
-            value={state.name}
-            onChange={(e) => {
-              setState({ name: e.target.value });
-            }}
-            placeholder={"Transformer Name"}
-            className="saved-transformer-name"
-            onBlur={notifyStateIsDirty}
-          />
-        </div>
-      )}
       {order.map((component) => {
         if (
           init.toggle &&
@@ -502,7 +492,22 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
         ) {
           return <></>;
         }
-        if (component === "context1" || component === "context2") {
+        if (component === "name" && saveData === undefined) {
+          return (
+            <div className="input-group">
+              <h3>Transformer Name</h3>
+              <TextInput
+                value={state.name}
+                onChange={(e) => {
+                  setState({ name: e.target.value });
+                }}
+                placeholder={init[component]?.placeholder || "Transformer Name"}
+                className="saved-transformer-name"
+                onBlur={notifyStateIsDirty}
+              />
+            </div>
+          );
+        } else if (component === "context1" || component === "context2") {
           return (
             <div className="input-group">
               {titleFromComponent(component, init)}

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -333,16 +333,16 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
     notifyInteractiveFrameIsDirty();
   }
 
-  // Place description after formula expression if there is one. If there is
-  // not, place it at the end.
+  // Place purpose statement between the type contract and the formula if there
+  // is one. If there is not, place it at the end.
   function placeDescription(order: string[]) {
     const firstIndex = order.findIndex((comp) => comp.startsWith("expression"));
 
-    // Insert purpose statement input before the expression.
     if (firstIndex === -1) {
       order.push("description");
     } else {
-      order.splice(firstIndex - 1, 0, "description");
+      // Insert purpose statement input before the expression.
+      order.splice(firstIndex, 0, "description");
     }
   }
 

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -80,7 +80,7 @@ interface ToggleDropdownInit extends ComponentInit {
     }
   >;
 }
-interface NameInit extends ComponentInit {
+interface NameInit {
   placeholder?: string;
 }
 interface ExpressionInit extends ComponentInit {}
@@ -210,11 +210,16 @@ const convertNames = (
   destinationNameRoot: string
 ) => destinationNameRoot + sourceName.slice(sourceNameRoot.length);
 
+type ComponentWithTitle = Exclude<
+  keyof TransformerTemplateInit,
+  "purposeStatement" | "name"
+>;
+
 /**
  * Makes a header from a ui component's title
  */
 const titleFromComponent = (
-  component: Exclude<keyof TransformerTemplateInit, "purposeStatement">,
+  component: ComponentWithTitle,
   init: TransformerTemplateInit
 ): ReactElement => {
   const tmp = init[component];
@@ -226,7 +231,7 @@ const titleFromComponent = (
  * This is used for displaying prompts for formulas.
  */
 const displayExpressionPrompt = (
-  component: Exclude<keyof TransformerTemplateInit, "purposeStatement">,
+  component: ComponentWithTitle,
   init: TransformerTemplateInit,
   state: TransformerTemplateState
 ): ReactElement => {

--- a/src/components/transformer-template/styles/DefinitionCreator.css
+++ b/src/components/transformer-template/styles/DefinitionCreator.css
@@ -14,7 +14,7 @@
   display: block;
   border: solid 1px var(--blue-green);
   border-radius: 3px;
-  height: 60px;
+  height: 40px;
   width: 300px;
 }
 

--- a/src/components/transformer-template/styles/TransformerTemplate.css
+++ b/src/components/transformer-template/styles/TransformerTemplate.css
@@ -3,7 +3,6 @@
   margin-top: 10px;
   background-color: #daeef1;
   position: relative;
-
 }
 
 #applyTransformer:hover {

--- a/src/components/ui-components/Select.tsx
+++ b/src/components/ui-components/Select.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from "react";
 interface SelectProps<T extends string | number> {
   onChange?: React.ChangeEventHandler<HTMLSelectElement>;
   defaultValue: T;
+  defaultTitle?: T;
   value: T | null;
   options: {
     value: T;
@@ -16,6 +17,7 @@ export default function Select<T extends string | number>({
   onChange,
   value,
   defaultValue,
+  defaultTitle,
   options,
   disabled,
   tooltip,
@@ -35,7 +37,7 @@ export default function Select<T extends string | number>({
       title={tooltip}
     >
       <option disabled value={defaultValue}>
-        {defaultValue}
+        {defaultTitle || defaultValue}
       </option>
       {options.map((option) => (
         <option key={option.value} value={option.value}>

--- a/src/lib/codapPhone/index.ts
+++ b/src/lib/codapPhone/index.ts
@@ -85,8 +85,8 @@ const phone: CodapPhone = new IframePhoneRpcEndpoint(
 );
 
 const DEFAULT_PLUGIN_WIDTH = 350;
-const DEFAULT_PLUGIN_HEIGHT = 465;
-const DEFAULT_SAVED_TRANSFORMER_HEIGHT = 370;
+const DEFAULT_PLUGIN_HEIGHT = 585;
+const DEFAULT_SAVED_TRANSFORMER_HEIGHT = 470;
 
 // Initialize the interactive frame with a given title.
 export async function initPhone(title: string, saved: boolean): Promise<void> {

--- a/src/lib/utils/__tests__/typeChecking.test.ts
+++ b/src/lib/utils/__tests__/typeChecking.test.ts
@@ -1,0 +1,44 @@
+import { inferType, inferTypeSingle } from "../typeChecking";
+
+test("infer basic number type", () => {
+  expect(inferTypeSingle(30)).toBe("Number");
+});
+
+test("infer string number type", () => {
+  expect(inferTypeSingle("30")).toBe("Number");
+  expect(inferTypeSingle("0.1")).toBe("Number");
+});
+
+test("infer basic boolean type", () => {
+  expect(inferTypeSingle(true)).toBe("Boolean");
+  expect(inferTypeSingle(false)).toBe("Boolean");
+});
+
+test("infer string boolean type", () => {
+  expect(inferTypeSingle("true")).toBe("Boolean");
+  expect(inferTypeSingle("false")).toBe("Boolean");
+});
+
+test("infer string that starts with number", () => {
+  expect(inferTypeSingle("10hello")).toBe("String");
+});
+
+test("infer singleton array with number", () => {
+  expect(inferType([30])).toBe("Number");
+  expect(inferType(["30"])).toBe("Number");
+});
+
+test("infer multiple numbers", () => {
+  expect(inferType([10, 20, 30, 0.1])).toBe("Number");
+  expect(inferType([10, 20, "0.1", 50])).toBe("Number");
+  expect(inferType(["20", "35.2", 20])).toBe("Number");
+  expect(inferType(["10", "20", "3.5", "50", "100"])).toBe("Number");
+  expect(inferType(["10", "20"])).toBe("Number");
+});
+
+test("infer mixed numbers and strings", () => {
+  expect(inferType(["10", "Not a number"])).toBe("String");
+
+  // This is not a string since the first few elements are actually numbers
+  expect(inferType([20, 50, 40, "10startswithnumber"])).toBe("Any");
+});

--- a/src/lib/utils/typeChecking.ts
+++ b/src/lib/utils/typeChecking.ts
@@ -103,3 +103,55 @@ export async function checkTypeOfValues(
 
   return failingIndices;
 }
+
+/**
+ * Infer the most precise type for a list of values.
+ * @param values - list of values of which to infer the type
+ * @returns the inferred type
+ */
+export function inferType(values: unknown[]): CodapLanguageType {
+  if (values.length == 0) {
+    return "Any";
+  }
+  const first = values[0];
+  const firstActualType = typeof first;
+  let candidateType = inferTypeSingle(first);
+  for (const value of values) {
+    const actualType = typeof value;
+    const valueType = inferTypeSingle(value);
+    if (valueType !== candidateType) {
+      if (firstActualType === "string" && actualType === "string") {
+        candidateType = "String";
+      } else {
+        return "Any";
+      }
+    }
+  }
+  return candidateType;
+}
+
+export function inferTypeSingle(value: unknown): CodapLanguageType {
+  if (typeof value === "number") {
+    return "Number";
+  }
+  if (typeof value === "boolean") {
+    return "Boolean";
+  }
+  if (typeof value === "object") {
+    return "Boundary";
+  }
+
+  // calling `Number` on whitespace will give '0', which might lead us to
+  // incorrectly infer the type to be number
+  if (typeof value === "string" && value.trim() === "") {
+    return "String";
+  }
+  // calling `Number` on "true" and "false" will give number outputs.
+  if (value === "true" || value === "false") {
+    return "Boolean";
+  }
+  if (!isNaN(Number(value))) {
+    return "Number";
+  }
+  return "String";
+}

--- a/src/strings/en/errors.ts
+++ b/src/strings/en/errors.ts
@@ -125,6 +125,9 @@ const errors = {
       "Please provide a key expression that evaluates to the same type for all cases. Got keys of different types {{ value1 }} and {{ value2 }}",
     noKeyExpression: "Please enter a key expression",
     noSortDirection: "Please select a sort direction",
+    noSortMethod: "Please select a sort method",
+    noSortAttribute: "Please select an attribute by which to sort",
+    attributeTypeAny: "Cannot sort an attribute with mixed type",
   },
   sumProduct: {
     noAttribute:

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -129,15 +129,12 @@ function docLinkFromHeadingID(headingID: string): string {
 const EXPRESSION_PLACEHOLDER = "What does the expression do to each row?";
 const TRANSFORMER_PLACEHOLDER = "What does the transformer do to its inputs?";
 
-const TRANSFORMER_NAME_TITLE = "Transformer Name";
-
 const transformerList: TransformerList = {
   "Build Attribute": {
     group: "Constructing",
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. with-new-attribute",
         },
         context1: {
@@ -186,7 +183,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. feet-to-inches",
         },
         context1: {
@@ -230,7 +226,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. older-than-50",
         },
         context1: {
@@ -266,7 +261,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. sort-by-height",
         },
         context1: {
@@ -334,7 +328,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. average-height",
         },
         context1: {
@@ -364,7 +357,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. median-shoe-size",
         },
         context1: {
@@ -396,7 +388,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. mode-height",
         },
         context1: {
@@ -427,7 +418,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. std-dev-of-age",
         },
         context1: {
@@ -458,7 +448,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. running-age",
         },
         context1: {
@@ -490,7 +479,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. running-mean-age",
         },
         context1: {
@@ -523,7 +511,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. running-min-age",
         },
         context1: {
@@ -555,7 +542,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. running-max-age",
         },
         context1: {
@@ -587,7 +573,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. height-differences",
         },
         context1: {
@@ -620,7 +605,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. difference-from-max",
         },
         context1: {
@@ -660,7 +644,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. weighted-avg-height",
         },
         context1: {
@@ -708,7 +691,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. compute-final-grade",
         },
         context1: {
@@ -742,7 +724,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. count-colors",
         },
         context1: {
@@ -776,7 +757,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. compare-scores",
         },
         context1: {
@@ -826,7 +806,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. group-by-state",
         },
         context1: {
@@ -857,7 +836,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. select-height-and-age",
         },
         context1: {
@@ -909,7 +887,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. combine-people-datasets",
         },
         context1: {
@@ -946,7 +923,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. partition-by-state",
         },
         context1: {
@@ -982,7 +958,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. flatten",
         },
         context1: {
@@ -1008,7 +983,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. join-on-id",
         },
         context1: {
@@ -1055,7 +1029,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. join-on-id",
         },
         context1: {
@@ -1114,7 +1087,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. pivot-longer-assessments",
         },
         context1: {
@@ -1158,7 +1130,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. pivot-wider-assessments",
         },
         context1: {
@@ -1198,7 +1169,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. uneditable-copy",
         },
         context1: {
@@ -1224,7 +1194,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. editable-copy",
         },
         context1: {
@@ -1254,7 +1223,6 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          title: TRANSFORMER_NAME_TITLE,
           placeholder: "e.g. copy-structure",
         },
         context1: {

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -135,7 +135,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. with-new-attribute",
+          placeholder: "e.g. build-kilos",
         },
         context1: {
           title: "Dataset to Add Attribute To",
@@ -183,7 +183,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. feet-to-inches",
+          placeholder: "e.g. lbs-to-kg",
         },
         context1: {
           title: "Dataset to Transform Attribute Of",
@@ -226,7 +226,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. older-than-50",
+          placeholder: "e.g. filter-is-heavy",
         },
         context1: {
           title: "Dataset to Filter",
@@ -261,7 +261,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. sort-by-height",
+          placeholder: "e.g. order-by-pounds",
         },
         context1: {
           title: "Dataset to sort",
@@ -328,7 +328,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. average-height",
+          placeholder: "e.g. average-weight",
         },
         context1: {
           title: "Dataset to Compute Mean Over",
@@ -357,7 +357,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. median-shoe-size",
+          placeholder: "e.g. median-time-to-adopt",
         },
         context1: {
           title: "Dataset to Compute Median Over",
@@ -388,7 +388,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. mode-height",
+          placeholder: "e.g. mode-num-legs",
         },
         context1: {
           title: "Dataset to Compute Mode Over",
@@ -448,7 +448,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. running-age",
+          placeholder: "e.g. running-sum-age",
         },
         context1: {
           title: "Dataset to calculate running sum on",
@@ -573,7 +573,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. height-differences",
+          placeholder: "e.g. weight-differences",
         },
         context1: {
           title: "Dataset to calculate difference on",
@@ -605,7 +605,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. difference-from-max",
+          placeholder: "e.g. diff-from-max-age",
         },
         context1: {
           title: "Dataset to calculate difference on",
@@ -644,7 +644,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. weighted-avg-height",
+          placeholder: "e.g. total-number-of-toes",
         },
         context1: {
           title: "Dataset to Reduce",
@@ -691,7 +691,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. compute-final-grade",
+          placeholder: "e.g. compute-weighted-avg",
         },
         context1: {
           title: "Dataset to Take Sum Product of",
@@ -724,7 +724,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. count-colors",
+          placeholder: "e.g. count-species",
         },
         context1: {
           title: "Dataset to Count",
@@ -757,7 +757,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. compare-scores",
+          placeholder: "e.g. compare-change-in-weight",
         },
         context1: {
           title: "Dataset to Compare",
@@ -806,7 +806,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. group-by-state",
+          placeholder: "e.g. group-by-species",
         },
         context1: {
           title: "Dataset to Group",
@@ -836,7 +836,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. select-height-and-age",
+          placeholder: "e.g. select-name-and-weight",
         },
         context1: {
           title: "Dataset to Select Attributes From",
@@ -887,7 +887,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. combine-people-datasets",
+          placeholder: "e.g. combine-animal-datasets",
         },
         context1: {
           title: "Base Dataset",
@@ -923,7 +923,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. partition-by-state",
+          placeholder: "e.g. partition-by-species",
         },
         context1: {
           title: "Dataset to Partition",
@@ -983,7 +983,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. join-on-id",
+          placeholder: "e.g. inner-join-on-name",
         },
         context1: {
           title: "Base Dataset",
@@ -1029,7 +1029,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g. join-on-id",
+          placeholder: "e.g. outer-join-on-name",
         },
         context1: {
           title: "Base Dataset",

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -129,11 +129,17 @@ function docLinkFromHeadingID(headingID: string): string {
 const EXPRESSION_PLACEHOLDER = "What does the expression do to each row?";
 const TRANSFORMER_PLACEHOLDER = "What does the transformer do to its inputs?";
 
+const TRANSFORMER_NAME_TITLE = "Transformer Name";
+
 const transformerList: TransformerList = {
   "Build Attribute": {
     group: "Constructing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. with-new-attribute",
+        },
         context1: {
           title: "Dataset to Add Attribute To",
         },
@@ -179,6 +185,10 @@ const transformerList: TransformerList = {
     group: "Constructing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. feet-to-inches",
+        },
         context1: {
           title: "Dataset to Transform Attribute Of",
         },
@@ -219,6 +229,10 @@ const transformerList: TransformerList = {
     group: "Constructing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. older-than-50",
+        },
         context1: {
           title: "Dataset to Filter",
         },
@@ -251,6 +265,10 @@ const transformerList: TransformerList = {
     group: "Constructing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. sort-by-height",
+        },
         context1: {
           title: "Dataset to sort",
         },
@@ -315,6 +333,10 @@ const transformerList: TransformerList = {
     group: "Measuring the Center",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. average-height",
+        },
         context1: {
           title: "Dataset to Compute Mean Over",
         },
@@ -341,6 +363,10 @@ const transformerList: TransformerList = {
     group: "Measuring the Center",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. median-shoe-size",
+        },
         context1: {
           title: "Dataset to Compute Median Over",
         },
@@ -369,6 +395,10 @@ const transformerList: TransformerList = {
     group: "Measuring the Center",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. mode-height",
+        },
         context1: {
           title: "Dataset to Compute Mode Over",
         },
@@ -396,6 +426,10 @@ const transformerList: TransformerList = {
     group: "Measuring the Center",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. std-dev-of-age",
+        },
         context1: {
           title: "Dataset to Compute Standard Deviation Over",
         },
@@ -423,6 +457,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. running-age",
+        },
         context1: {
           title: "Dataset to calculate running sum on",
         },
@@ -451,6 +489,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. running-mean-age",
+        },
         context1: {
           title: "Dataset to calculate running mean on",
         },
@@ -480,6 +522,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. running-min-age",
+        },
         context1: {
           title: "Dataset to calculate running min on",
         },
@@ -508,6 +554,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. running-max-age",
+        },
         context1: {
           title: "Dataset to calculate running max on",
         },
@@ -536,6 +586,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. height-differences",
+        },
         context1: {
           title: "Dataset to calculate difference on",
         },
@@ -565,6 +619,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. difference-from-max",
+        },
         context1: {
           title: "Dataset to calculate difference on",
         },
@@ -601,6 +659,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. weighted-avg-height",
+        },
         context1: {
           title: "Dataset to Reduce",
         },
@@ -645,6 +707,10 @@ const transformerList: TransformerList = {
     group: "Aggregating",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. compute-final-grade",
+        },
         context1: {
           title: "Dataset to Take Sum Product of",
         },
@@ -675,6 +741,10 @@ const transformerList: TransformerList = {
     group: "Summarizing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. count-colors",
+        },
         context1: {
           title: "Dataset to Count",
         },
@@ -705,6 +775,10 @@ const transformerList: TransformerList = {
     group: "Summarizing",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. compare-scores",
+        },
         context1: {
           title: "Dataset to Compare",
         },
@@ -751,6 +825,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. group-by-state",
+        },
         context1: {
           title: "Dataset to Group",
         },
@@ -778,6 +856,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. select-height-and-age",
+        },
         context1: {
           title: "Dataset to Select Attributes From",
         },
@@ -826,6 +908,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. combine-people-datasets",
+        },
         context1: {
           title: "Base Dataset",
         },
@@ -859,6 +945,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. partition-by-state",
+        },
         context1: {
           title: "Dataset to Partition",
         },
@@ -891,6 +981,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. flatten",
+        },
         context1: {
           title: "Dataset to Flatten",
         },
@@ -913,6 +1007,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. join-on-id",
+        },
         context1: {
           title: "Base Dataset",
         },
@@ -956,6 +1054,10 @@ const transformerList: TransformerList = {
     group: "Restructuring",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. join-on-id",
+        },
         context1: {
           title: "Base Dataset",
         },
@@ -1011,6 +1113,10 @@ const transformerList: TransformerList = {
     group: "Tidying Data",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. pivot-longer-assessments",
+        },
         context1: {
           title: "Dataset to Pivot",
         },
@@ -1051,6 +1157,10 @@ const transformerList: TransformerList = {
     group: "Tidying Data",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. pivot-wider-assessments",
+        },
         context1: {
           title: "Dataset to Pivot",
         },
@@ -1087,6 +1197,10 @@ const transformerList: TransformerList = {
     group: "Copying",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. uneditable-copy",
+        },
         context1: {
           title: "Dataset to Copy",
         },
@@ -1109,6 +1223,10 @@ const transformerList: TransformerList = {
     group: "Copying",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. editable-copy",
+        },
         context1: {
           title: "Dataset to Copy",
         },
@@ -1135,6 +1253,10 @@ const transformerList: TransformerList = {
     group: "Copying",
     componentData: {
       init: {
+        name: {
+          title: TRANSFORMER_NAME_TITLE,
+          placeholder: "e.g. copy-structure",
+        },
         context1: {
           title: "Dataset to Copy",
         },

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -125,6 +125,10 @@ function docLinkFromHeadingID(headingID: string): string {
   return `https://docs.google.com/document/d/1NZA9gxtu6jD3M-5SQyx0tvV2N5qYKMgRm1XUwMnLgJU/edit#heading=${headingID}`;
 }
 
+// Placeholder text for purpose statements
+const EXPRESSION_PLACEHOLDER = "What does the expression do to each row?";
+const TRANSFORMER_PLACEHOLDER = "What does the transformer do to its inputs?";
+
 const transformerList: TransformerList = {
   "Build Attribute": {
     group: "Constructing",
@@ -144,6 +148,9 @@ const transformerList: TransformerList = {
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
+        },
+        purposeStatement: {
+          placeholder: EXPRESSION_PLACEHOLDER,
         },
         expression1: {
           title:
@@ -184,6 +191,9 @@ const transformerList: TransformerList = {
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
         },
+        purposeStatement: {
+          placeholder: EXPRESSION_PLACEHOLDER,
+        },
         expression1: {
           title:
             "For each row, replace the value of attribute {attribute1} with the result of the expression:",
@@ -219,6 +229,9 @@ const transformerList: TransformerList = {
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
+        purposeStatement: {
+          placeholder: EXPRESSION_PLACEHOLDER,
+        },
         expression1: { title: "Keep all rows that satisfy:" },
       },
       transformerFunction: { kind: "datasetCreator", func: filter },
@@ -246,6 +259,9 @@ const transformerList: TransformerList = {
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
+        },
+        purposeStatement: {
+          placeholder: EXPRESSION_PLACEHOLDER,
         },
         expression1: {
           title:
@@ -285,6 +301,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Find Mean of",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: mean },
       info: {
@@ -307,6 +326,9 @@ const transformerList: TransformerList = {
         },
         attribute1: {
           title: "Attribute to Find Median of",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: median },
@@ -333,6 +355,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Find Mode of",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: mode },
       info: {
@@ -356,6 +381,9 @@ const transformerList: TransformerList = {
         },
         attribute1: {
           title: "Attribute to Find Standard Deviation of",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: standardDeviation },
@@ -381,6 +409,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Aggregate",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: runningSum },
       info: {
@@ -405,6 +436,9 @@ const transformerList: TransformerList = {
         },
         attribute1: {
           title: "Attribute to Aggregate",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: runningMean },
@@ -432,6 +466,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Aggregate",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: runningMin },
       info: {
@@ -457,6 +494,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Aggregate",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: runningMax },
       info: {
@@ -481,6 +521,9 @@ const transformerList: TransformerList = {
         },
         attribute1: {
           title: "Attribute to Aggregate",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: difference },
@@ -510,6 +553,9 @@ const transformerList: TransformerList = {
         },
         textInput2: {
           title: "Starting value for difference",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: {
@@ -543,6 +589,9 @@ const transformerList: TransformerList = {
         },
         textInput2: {
           title: "Accumulator Name",
+        },
+        purposeStatement: {
+          placeholder: EXPRESSION_PLACEHOLDER,
         },
         expression1: {
           title: "Starting with:",
@@ -582,6 +631,9 @@ const transformerList: TransformerList = {
         attributeSet1: {
           title: "Attributes to Take Sum Product of",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: sumProduct },
       info: {
@@ -608,6 +660,9 @@ const transformerList: TransformerList = {
         },
         attributeSet1: {
           title: "Attributes to Count",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: count },
@@ -648,6 +703,9 @@ const transformerList: TransformerList = {
           ],
           defaultValue: "Select a type",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: compare },
       info: {
@@ -678,6 +736,9 @@ const transformerList: TransformerList = {
         },
         attributeSet1: {
           title: "Attributes to Group By",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: groupBy },
@@ -717,6 +778,9 @@ const transformerList: TransformerList = {
         attributeSet1: {
           title: "Attributes",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: {
         kind: "datasetCreator",
@@ -748,6 +812,9 @@ const transformerList: TransformerList = {
         context2: {
           title: "Combining Dataset",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: {
         kind: "datasetCreator",
@@ -778,6 +845,9 @@ const transformerList: TransformerList = {
         attribute1: {
           title: "Attribute to Partition By",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: {
         kind: "fullOverride",
@@ -803,6 +873,9 @@ const transformerList: TransformerList = {
       init: {
         context1: {
           title: "Dataset to Flatten",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: flatten },
@@ -831,6 +904,9 @@ const transformerList: TransformerList = {
         },
         attribute2: {
           title: "Joining Attribute",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: innerJoin },
@@ -880,6 +956,9 @@ const transformerList: TransformerList = {
             { value: "full", title: "Full Outer Join" },
           ],
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: outerJoin },
       info: {
@@ -924,6 +1003,9 @@ const transformerList: TransformerList = {
         textInput2: {
           title: "Values To",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: pivotLonger },
       info: {
@@ -959,6 +1041,9 @@ const transformerList: TransformerList = {
           title: "Values From",
           context: "context1",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: pivotWider },
       info: {
@@ -985,6 +1070,9 @@ const transformerList: TransformerList = {
         context1: {
           title: "Dataset to Copy",
         },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: copy },
       info: {
@@ -1003,6 +1091,9 @@ const transformerList: TransformerList = {
       init: {
         context1: {
           title: "Dataset to Copy",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: {
@@ -1026,6 +1117,9 @@ const transformerList: TransformerList = {
       init: {
         context1: {
           title: "Dataset to Copy",
+        },
+        purposeStatement: {
+          placeholder: TRANSFORMER_PLACEHOLDER,
         },
       },
       transformerFunction: { kind: "datasetCreator", func: copyStructure },

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -144,7 +144,7 @@ const transformerList: TransformerList = {
           title: "Collection to Add To",
         },
         typeContract1: {
-          title: "Formula for Attribute Values",
+          title: "Formula for New Attribute Values",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
@@ -186,7 +186,7 @@ const transformerList: TransformerList = {
           title: "Attribute to Transform",
         },
         typeContract1: {
-          title: "Formula for Transformed Values",
+          title: "Formula for Transformed Attribute Values",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
@@ -223,7 +223,7 @@ const transformerList: TransformerList = {
           title: "Dataset to Filter",
         },
         typeContract1: {
-          title: "How to Filter",
+          title: "Formula to Filter By",
           inputTypes: "Row",
           outputTypes: "Boolean",
           inputTypeDisabled: true,
@@ -254,8 +254,25 @@ const transformerList: TransformerList = {
         context1: {
           title: "Dataset to sort",
         },
+        toggle: {
+          title: "Sort Method",
+          options: {
+            byAttribute: {
+              title: "By Attribute",
+              componentsHidden: ["typeContract1", "expression1", "description"],
+            },
+            byExpression: {
+              title: "By Expression",
+              componentsHidden: ["attribute1"],
+            },
+          },
+          defaultValue: "byAttribute",
+        },
+        attribute1: {
+          title: "Attribute to Sort By",
+        },
         typeContract1: {
-          title: "Key expression",
+          title: "Formula to Sort By",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
@@ -279,14 +296,17 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: sort },
       info: {
         summary:
-          "Takes a dataset and orders it, using the value of a formula to \
-          determine how cases should appear in order.",
+          'Takes a dataset and orders its cases, either by the values from a \
+          particular attribute (the "By Attribute" method), or the values \
+          produced by a formula (the "By Expression" method).',
         consumes:
-          "A dataset to sort, a formula ('key expression'), an indication of the \
-          type the formula evaluates to, and a sort direction (ascending or descending).",
+          "By Attribute: A dataset to sort, an attribute to sort by, and a sort \
+          direction (ascending or descending).\n\
+          By Expression: A dataset to sort, a formula, an indication of the type \
+          the formula evaluates to, and a sort direction (ascending or descending).",
         produces:
-          "A copy of the input dataset, with cases sorted by the value of the \
-          key expression.",
+          "A copy of the input dataset, with cases sorted according to the \
+          indicated method and direction.",
         docLink: docLinkFromHeadingID("h.9swamcujp916"),
       },
     },

--- a/src/transformers/__tests__/sort.test.ts
+++ b/src/transformers/__tests__/sort.test.ts
@@ -1,5 +1,9 @@
 import { evalExpression } from "../../lib/codapPhone";
-import { SortDirection, uncheckedSort } from "../sort";
+import {
+  SortDirection,
+  uncheckedSortByAttribute,
+  uncheckedSortByExpression,
+} from "../sort";
 import { CodapLanguageType, DataSet } from "../types";
 import {
   cloneDataSet,
@@ -17,14 +21,14 @@ import {
 /**
  * A wrapper around unchecked sort that discards the missing value report.
  */
-async function uncheckedSortWrapper(
+async function uncheckedSortByExpressionWrapper(
   dataset: DataSet,
   keyExpr: string,
   outputType: CodapLanguageType,
   sortDirection: SortDirection,
   evalFormula = evalExpression
 ): Promise<DataSet> {
-  const [output] = await uncheckedSort(
+  const [output] = await uncheckedSortByExpression(
     dataset,
     keyExpr,
     outputType,
@@ -34,9 +38,27 @@ async function uncheckedSortWrapper(
   return output;
 }
 
+/**
+ * A wrapper around unchecked sort that discards the missing value report.
+ */
+async function uncheckedSortByAttributeWrapper(
+  contextName: string,
+  attribute: string,
+  dataset: DataSet,
+  sortDirection: SortDirection
+): Promise<DataSet> {
+  const [output] = await uncheckedSortByAttribute(
+    contextName,
+    dataset,
+    attribute,
+    sortDirection
+  );
+  return output;
+}
+
 test("no change to dataset with no records", async () => {
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       EMPTY_RECORDS,
       "A",
       "Any",
@@ -54,7 +76,7 @@ test("sorts numbers", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "A",
       "Any",
@@ -70,13 +92,35 @@ test("sorts numbers", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "A",
       "Any",
       "descending",
       jsEvalExpression
     )
+  ).toEqual(sortedByADescending);
+});
+
+test("sorts numbers by attribute", async () => {
+  // ascending order
+  const sortedByAAscending = cloneDataSet(DATASET_A);
+  sortedByAAscending.records.sort(
+    (a, b) => (a["A"] as number) - (b["A"] as number)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "A", DATASET_A, "ascending")
+  ).toEqual(sortedByAAscending);
+
+  // descending order
+  const sortedByADescending = cloneDataSet(DATASET_A);
+  sortedByADescending.records.sort(
+    (a, b) => (b["A"] as number) - (a["A"] as number)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "A", DATASET_A, "descending")
   ).toEqual(sortedByADescending);
 });
 
@@ -94,7 +138,7 @@ test("sorts booleans", async () => {
     ]
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "B",
       "Any",
@@ -116,13 +160,47 @@ test("sorts booleans", async () => {
     ]
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "B",
       "Any",
       "ascending",
       jsEvalExpression
     )
+  ).toEqual(sortedByBAscending);
+});
+
+test("sorts booleans by attribute", async () => {
+  // descending is true before false
+  const sortedByBDescending = cloneDataSet(DATASET_A);
+  sortedByBDescending.records = makeRecords(
+    ["A", "B", "C"],
+    [
+      [3, true, 2000],
+      [8, true, 2003],
+      [4, true, 2010],
+      [10, false, 1998],
+      [10, false, 2014],
+    ]
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper("", "B", DATASET_A, "descending")
+  ).toEqual(sortedByBDescending);
+
+  // ascending is true before false
+  const sortedByBAscending = cloneDataSet(DATASET_A);
+  sortedByBAscending.records = makeRecords(
+    ["A", "B", "C"],
+    [
+      [10, false, 1998],
+      [10, false, 2014],
+      [3, true, 2000],
+      [8, true, 2003],
+      [4, true, 2010],
+    ]
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper("", "B", DATASET_A, "ascending")
   ).toEqual(sortedByBAscending);
 });
 
@@ -143,7 +221,7 @@ test("sorts strings", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_B,
       "Name",
       "Any",
@@ -158,13 +236,33 @@ test("sorts strings", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_B,
       "Name",
       "Any",
       "descending",
       jsEvalExpression
     )
+  ).toEqual(sortedByNameDescending);
+});
+
+test("sorts strings by attribute", async () => {
+  const sortedByNameAscending = cloneDataSet(DATASET_B);
+  sortedByNameAscending.records.sort((aRec, bRec) =>
+    sortStr(aRec["Name"] as string, bRec["Name"] as string)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "Name", DATASET_B, "ascending")
+  ).toEqual(sortedByNameAscending);
+
+  const sortedByNameDescending = cloneDataSet(DATASET_B);
+  sortedByNameDescending.records.sort((aRec, bRec) =>
+    sortStr(bRec["Name"] as string, aRec["Name"] as string)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "Name", DATASET_B, "descending")
   ).toEqual(sortedByNameDescending);
 });
 
@@ -188,7 +286,7 @@ test("sorts objects", async () => {
     sortStr(JSON.stringify(a["Boundaries"]), JSON.stringify(b["Boundaries"]))
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       withObjects,
       "Boundaries",
       "Any",
@@ -202,7 +300,7 @@ test("sorts objects", async () => {
     sortStr(JSON.stringify(b["Boundaries"]), JSON.stringify(a["Boundaries"]))
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       withObjects,
       "Boundaries",
       "Any",
@@ -213,7 +311,7 @@ test("sorts objects", async () => {
 
   // All the boundaries are the same in the TYPES_DATASET
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       TYPES_DATASET,
       "Boundary",
       "Any",
@@ -222,7 +320,7 @@ test("sorts objects", async () => {
     )
   ).toEqual(TYPES_DATASET);
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       TYPES_DATASET,
       "Boundary",
       "Any",
@@ -232,10 +330,70 @@ test("sorts objects", async () => {
   ).toEqual(TYPES_DATASET);
 });
 
+test("sorts objects by attribute", async () => {
+  const withObjects = {
+    collections: [makeCollection("Collection", ["Boundaries"])],
+    records: makeRecords(
+      ["Boundaries"],
+      [
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+      ]
+    ),
+  };
+
+  const sortedWithObjectsAsc = cloneDataSet(withObjects);
+  sortedWithObjectsAsc.records.sort((a, b) =>
+    sortStr(JSON.stringify(a["Boundaries"]), JSON.stringify(b["Boundaries"]))
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundaries",
+      withObjects,
+      "ascending"
+    )
+  ).toEqual(sortedWithObjectsAsc);
+
+  const sortedWithObjectsDesc = cloneDataSet(withObjects);
+  sortedWithObjectsDesc.records.sort((a, b) =>
+    sortStr(JSON.stringify(b["Boundaries"]), JSON.stringify(a["Boundaries"]))
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundaries",
+      withObjects,
+      "descending"
+    )
+  ).toEqual(sortedWithObjectsDesc);
+
+  // All the boundaries are the same in the TYPES_DATASET
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundary",
+      TYPES_DATASET,
+      "ascending"
+    )
+  ).toEqual(TYPES_DATASET);
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundary",
+      TYPES_DATASET,
+      "descending"
+    )
+  ).toEqual(TYPES_DATASET);
+});
+
 test("errors when key expression evaluates to multiple types", async () => {
   expect.assertions(2);
   try {
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_3",
       "Any",
@@ -247,7 +405,7 @@ test("errors when key expression evaluates to multiple types", async () => {
   }
 
   try {
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_5",
       "Any",
@@ -276,13 +434,47 @@ test("sort is stable", async () => {
   };
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       dataset,
       "Number",
       "Any",
       "ascending",
       jsEvalExpression
     )
+  ).toEqual({
+    collections: dataset.collections,
+    records: makeRecords(
+      ["Letter", "Number"],
+      [
+        ["D", 1],
+        ["C", 2],
+        ["E", 2],
+        ["A", 3],
+        ["B", 3],
+        ["F", 6],
+      ]
+    ),
+  });
+});
+
+test("sort is stable by attribute", async () => {
+  const dataset = {
+    collections: [makeCollection("Collection", ["Letter", "Number"])],
+    records: makeRecords(
+      ["Letter", "Number"],
+      [
+        ["A", 3],
+        ["B", 3],
+        ["C", 2],
+        ["D", 1],
+        ["E", 2],
+        ["F", 6],
+      ]
+    ),
+  };
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "Number", dataset, "ascending")
   ).toEqual({
     collections: dataset.collections,
     records: makeRecords(

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -8,6 +8,7 @@ import ErrorDisplay, {
 import { SavedTransformer } from "../components/transformer-template/types";
 import { TextInput } from "../components/ui-components";
 import {
+  getAllComponents,
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
   updateInteractiveFrame,
@@ -158,22 +159,46 @@ function SavedDefinitionView({
       />
       <button
         id="edit-button"
-        onClick={() => {
+        onClick={async () => {
           // clear the transformer application error message
           setErrMsg(null, errorId);
 
+          const new_name = savedTransformer.name.trim();
+
           // if going to non-editable (saving) and name is blank
-          if (editable && savedTransformer.name.trim() === "") {
+          if (editable && new_name === "") {
             setSaveErr("Please choose a name for the transformer");
             return;
+          }
+
+          const full_name = `Transformer: ${new_name}`;
+
+          // check if trying to save with a name that another transformer already uses
+          if (editable) {
+            const components = await getAllComponents();
+            const currentName = (await getInteractiveFrame()).title;
+
+            // Add an extra clause to the conditional to allow a duplicate name if
+            // we're just saving this transformer with the name it already had
+            if (
+              components.find(
+                (c) => c.title === full_name && c.title !== currentName
+              )
+            ) {
+              setSaveErr("A transformer with that name already exists");
+              return;
+            }
           }
 
           // if saving, update the interactive frame to use the new transformer name
           if (editable) {
             updateInteractiveFrame({
-              title: `Transformer: ${savedTransformer.name}`,
+              title: full_name,
             });
           }
+
+          // ensure that whitespace trimming is reflected in textbox
+          setSavedTransformer({ ...savedTransformer, name: new_name });
 
           setEditable(!editable);
         }}

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -149,26 +149,6 @@ function SavedDefinitionView({
           </IconButton>
         </div>
       )}
-      {editable ? (
-        <>
-          <TextArea
-            value={savedTransformer.description || ""}
-            onChange={(e) => {
-              setSavedTransformer({
-                ...savedTransformer,
-                description: e.target.value,
-              });
-              setSaveErr(null);
-            }}
-            placeholder="Purpose Statement"
-            className="purpose-statement"
-            onBlur={notifyStateIsDirty}
-          />
-          <hr className="divider" />
-        </>
-      ) : (
-        savedTransformer.description && <p>{savedTransformer.description}</p>
-      )}
       <TransformerRenderer
         setErrMsg={setErrMsg}
         errorDisplay={<ErrorDisplay setErrMsg={setErrMsg} store={errorStore} />}

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -6,7 +6,7 @@ import ErrorDisplay, {
   useErrorStore,
 } from "../components/ui-components/Error";
 import { SavedTransformer } from "../components/transformer-template/types";
-import { TextArea, TextInput } from "../components/ui-components";
+import { TextInput } from "../components/ui-components";
 import {
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -60,13 +60,17 @@ function SavedDefinitionView({
       if (savedState === undefined) {
         return;
       }
-      if (savedState.savedTransformation) {
-        setSavedTransformer({
-          ...savedTransformer,
-          name: savedState.savedTransformation.name,
-          description: savedState.savedTransformation.description,
-        });
-      }
+      setSavedTransformer((oldSavedTransformer) => {
+        if (savedState.savedTransformation !== undefined) {
+          return {
+            ...oldSavedTransformer,
+            name: savedState.savedTransformation.name,
+            description: savedState.savedTransformation.description,
+          };
+        } else {
+          return oldSavedTransformer;
+        }
+      });
       if (savedState.activeTransformations) {
         activeTransformationsDispatch({
           type: ActionTypes.SET,
@@ -81,8 +85,10 @@ function SavedDefinitionView({
     }
     fetchSavedState();
 
-    // Identity of dispatch is stable since it came from useReducer
-  }, [activeTransformationsDispatch, savedTransformer, setEditedOutputs]);
+    // Identity of dispatch is stable since it came from useReducer, same with
+    // setEditedOutputs. Fetching saved state should only run once.
+    // eslint-disable-next-line
+  }, []);
 
   // Register a listener to generate the plugin's state
   useEffect(() => {


### PR DESCRIPTION
Resolves #231.

Transformer with formula:
![image](https://user-images.githubusercontent.com/11802391/160094475-7408ebc6-bd27-47cf-a790-01d08c95cd0e.png)

Transformer without formula:
![image](https://user-images.githubusercontent.com/11802391/160094563-d2049dec-2e4b-4e7c-a773-592f8367b2ee.png)

Things to tweak:
- Should purpose statement have its own heading or be included in the expression input?
- We could remove the toggle for the save button since it's just a single button now.

Edit: Updated screenshots.