### PR TITLE
Support two kinds of sort

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -603,20 +603,22 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
           return tmp ? (
             <div className="input-group">
               {titleFromComponent(component, init)}
-              <Select
+              <select
                 onChange={(e) => {
                   notifyStateIsDirty();
                   setState({ [component]: e.target.value });
                 }}
-                options={Object.entries(tmp.options).map(([key, values]) => ({
-                  title: values.title,
-                  value: key,
-                }))}
-                value={state[component]}
-                defaultValue={tmp.defaultValue}
-                defaultTitle={tmp.options[tmp.defaultValue].title}
+                // Safe cast, since we ensure that toggle state is initialized.
+                // Otherwise, the component exists in an impossible state.
+                value={state[component] as string}
                 disabled={!editable}
-              />
+              >
+                {Object.entries(tmp.options).map(([key, values]) => (
+                  <option key={key} value={key}>
+                    {values.title}
+                  </option>
+                ))}
+              </select>
             </div>
           ) : (
             `${component} used but undefined`

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -70,6 +70,16 @@ interface DropdownInit extends ComponentInit {
     value: string;
   }[];
 }
+interface ToggleDropdownInit extends ComponentInit {
+  defaultValue: string;
+  options: Record<
+    string,
+    {
+      title: string;
+      componentsHidden: string[];
+    }
+  >;
+}
 interface ExpressionInit extends ComponentInit {}
 interface TypeContractInit extends ComponentInit {
   inputTypes: string[] | string;
@@ -78,6 +88,7 @@ interface TypeContractInit extends ComponentInit {
   outputTypeDisabled?: boolean;
 }
 export type TransformerTemplateInit = {
+  toggle?: ToggleDropdownInit;
   context1?: ContextInit;
   context2?: ContextInit;
   collection1?: CollectionInit;
@@ -103,6 +114,7 @@ type AttributeState = string | null;
 type AttributeSetState = string[];
 type TextInputState = string;
 type DropdownState = string | null;
+type ToggleDropdownState = string | null;
 type ExpressionState = string;
 type TypeContractState = {
   inputType: CodapLanguageType;
@@ -111,6 +123,7 @@ type TypeContractState = {
 export type TransformerTemplateState = {
   name: string;
   description: string;
+  toggle: ToggleDropdownState;
   context1: ContextState;
   context2: ContextState;
   collection1: CollectionState;
@@ -132,6 +145,7 @@ export type TransformerTemplateState = {
 const DEFAULT_STATE: TransformerTemplateState = {
   name: "",
   description: "",
+  toggle: null,
   context1: null,
   context2: null,
   collection1: null,
@@ -482,6 +496,14 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
         </div>
       )}
       {order.map((component) => {
+        if (
+          init.toggle &&
+          init.toggle.options[
+            state.toggle || init.toggle.defaultValue
+          ].componentsHidden.includes(component)
+        ) {
+          return <></>;
+        }
         if (component === "context1" || component === "context2") {
           return (
             <div className="input-group">
@@ -567,6 +589,29 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
                 onBlur={notifyStateIsDirty}
               />
             </div>
+          );
+        } else if (component === "toggle") {
+          const tmp = init[component];
+          return tmp ? (
+            <div className="input-group">
+              {titleFromComponent(component, init)}
+              <Select
+                onChange={(e) => {
+                  notifyStateIsDirty();
+                  setState({ [component]: e.target.value });
+                }}
+                options={Object.entries(tmp.options).map(([key, values]) => ({
+                  title: values.title,
+                  value: key,
+                }))}
+                value={state[component]}
+                defaultValue={tmp.defaultValue}
+                defaultTitle={tmp.options[tmp.defaultValue].title}
+                disabled={!editable}
+              />
+            </div>
+          ) : (
+            `${component} used but undefined`
           );
         } else if (component === "dropdown1" || component === "dropdown2") {
           const tmp = init[component];

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -364,7 +364,16 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
   // if there isn't any save data)
   useEffect(() => {
     if (saveData === undefined) {
-      setState(DEFAULT_STATE);
+      const defaultState = { ...DEFAULT_STATE };
+
+      // Must initialize toggle. The transformer must be in one of the toggle
+      // states at a time, and if no options are chosen, the transformer will be
+      // in an impossible state. E.g. both sorting by attribute and sorting by
+      // expression.
+      if (init.toggle) {
+        defaultState.toggle = init.toggle.defaultValue;
+      }
+      setState(defaultState);
       setErrMsg(null, errorId);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -498,9 +507,8 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
       {order.map((component) => {
         if (
           init.toggle &&
-          init.toggle.options[
-            state.toggle || init.toggle.defaultValue
-          ].componentsHidden.includes(component)
+          state.toggle &&
+          init.toggle.options[state.toggle].componentsHidden.includes(component)
         ) {
           return <></>;
         }

--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -126,7 +126,6 @@ type TypeContractState = {
 };
 export type TransformerTemplateState = {
   name: string;
-  description: string;
   toggle: ToggleDropdownState;
   purposeStatement: string;
   context1: ContextState;
@@ -149,7 +148,6 @@ export type TransformerTemplateState = {
 
 const DEFAULT_STATE: TransformerTemplateState = {
   name: "",
-  description: "",
   toggle: null,
   purposeStatement: "",
   context1: null,

--- a/src/components/ui-components/Select.tsx
+++ b/src/components/ui-components/Select.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from "react";
 interface SelectProps<T extends string | number> {
   onChange?: React.ChangeEventHandler<HTMLSelectElement>;
   defaultValue: T;
+  defaultTitle?: T;
   value: T | null;
   options: {
     value: T;
@@ -16,6 +17,7 @@ export default function Select<T extends string | number>({
   onChange,
   value,
   defaultValue,
+  defaultTitle,
   options,
   disabled,
   tooltip,
@@ -35,7 +37,7 @@ export default function Select<T extends string | number>({
       title={tooltip}
     >
       <option disabled value={defaultValue}>
-        {defaultValue}
+        {defaultTitle || defaultValue}
       </option>
       {options.map((option) => (
         <option key={option.value} value={option.value}>

--- a/src/lib/utils/__tests__/typeChecking.test.ts
+++ b/src/lib/utils/__tests__/typeChecking.test.ts
@@ -1,0 +1,44 @@
+import { inferType, inferTypeSingle } from "../typeChecking";
+
+test("infer basic number type", () => {
+  expect(inferTypeSingle(30)).toBe("Number");
+});
+
+test("infer string number type", () => {
+  expect(inferTypeSingle("30")).toBe("Number");
+  expect(inferTypeSingle("0.1")).toBe("Number");
+});
+
+test("infer basic boolean type", () => {
+  expect(inferTypeSingle(true)).toBe("Boolean");
+  expect(inferTypeSingle(false)).toBe("Boolean");
+});
+
+test("infer string boolean type", () => {
+  expect(inferTypeSingle("true")).toBe("Boolean");
+  expect(inferTypeSingle("false")).toBe("Boolean");
+});
+
+test("infer string that starts with number", () => {
+  expect(inferTypeSingle("10hello")).toBe("String");
+});
+
+test("infer singleton array with number", () => {
+  expect(inferType([30])).toBe("Number");
+  expect(inferType(["30"])).toBe("Number");
+});
+
+test("infer multiple numbers", () => {
+  expect(inferType([10, 20, 30, 0.1])).toBe("Number");
+  expect(inferType([10, 20, "0.1", 50])).toBe("Number");
+  expect(inferType(["20", "35.2", 20])).toBe("Number");
+  expect(inferType(["10", "20", "3.5", "50", "100"])).toBe("Number");
+  expect(inferType(["10", "20"])).toBe("Number");
+});
+
+test("infer mixed numbers and strings", () => {
+  expect(inferType(["10", "Not a number"])).toBe("String");
+
+  // This is not a string since the first few elements are actually numbers
+  expect(inferType([20, 50, 40, "10startswithnumber"])).toBe("Any");
+});

--- a/src/lib/utils/typeChecking.ts
+++ b/src/lib/utils/typeChecking.ts
@@ -121,7 +121,7 @@ export function inferType(values: unknown[]): CodapLanguageType {
     const valueType = inferTypeSingle(value);
     if (valueType !== candidateType) {
       if (firstActualType === "string" && actualType === "string") {
-        candidateType = "String"
+        candidateType = "String";
       } else {
         return "Any";
       }

--- a/src/strings/en/errors.ts
+++ b/src/strings/en/errors.ts
@@ -125,6 +125,8 @@ const errors = {
       "Please provide a key expression that evaluates to the same type for all cases. Got keys of different types {{ value1 }} and {{ value2 }}",
     noKeyExpression: "Please enter a key expression",
     noSortDirection: "Please select a sort direction",
+    noSortMethod: "Please select a sort method",
+    noSortAttribute: "Please select an attribute by which to sort",
   },
   sumProduct: {
     noAttribute:

--- a/src/strings/en/errors.ts
+++ b/src/strings/en/errors.ts
@@ -127,6 +127,7 @@ const errors = {
     noSortDirection: "Please select a sort direction",
     noSortMethod: "Please select a sort method",
     noSortAttribute: "Please select an attribute by which to sort",
+    attributeTypeAny: "Cannot sort an attribute with mixed type",
   },
   sumProduct: {
     noAttribute:

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -140,7 +140,7 @@ const transformerList: TransformerList = {
           title: "Collection to Add To",
         },
         typeContract1: {
-          title: "Formula for Attribute Values",
+          title: "Formula for New Attribute Values",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
@@ -179,7 +179,7 @@ const transformerList: TransformerList = {
           title: "Attribute to Transform",
         },
         typeContract1: {
-          title: "Formula for Transformed Values",
+          title: "Formula for Transformed Attribute Values",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,
@@ -213,7 +213,7 @@ const transformerList: TransformerList = {
           title: "Dataset to Filter",
         },
         typeContract1: {
-          title: "How to Filter",
+          title: "Formula to Filter By",
           inputTypes: "Row",
           outputTypes: "Boolean",
           inputTypeDisabled: true,
@@ -242,24 +242,24 @@ const transformerList: TransformerList = {
           title: "Dataset to sort",
         },
         toggle: {
-          title: "Sort method",
+          title: "Sort Method",
           options: {
             byAttribute: {
-              title: "by attribute",
+              title: "By Attribute",
               componentsHidden: ["typeContract1", "expression1", "description"],
             },
             byExpression: {
-              title: "by expression",
+              title: "By Expression",
               componentsHidden: ["attribute1"],
             },
           },
           defaultValue: "byAttribute",
         },
         attribute1: {
-          title: "Attribute to sort",
+          title: "Attribute to Sort By",
         },
         typeContract1: {
-          title: "Key expression",
+          title: "Formula to Sort By",
           inputTypes: "Row",
           outputTypes: codapLanguageTypes,
           inputTypeDisabled: true,

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -241,6 +241,23 @@ const transformerList: TransformerList = {
         context1: {
           title: "Dataset to sort",
         },
+        toggle: {
+          title: "Sort method",
+          options: {
+            byAttribute: {
+              title: "by attribute",
+              componentsHidden: ["typeContract1", "expression1", "description"],
+            },
+            byExpression: {
+              title: "by expression",
+              componentsHidden: ["dropdown1"],
+            },
+          },
+          defaultValue: "byAttribute",
+        },
+        attribute1: {
+          title: "Attribute to sort",
+        },
         typeContract1: {
           title: "Key expression",
           inputTypes: "Row",

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -250,7 +250,7 @@ const transformerList: TransformerList = {
             },
             byExpression: {
               title: "by expression",
-              componentsHidden: ["dropdown1"],
+              componentsHidden: ["attribute1"],
             },
           },
           defaultValue: "byAttribute",

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -280,14 +280,17 @@ const transformerList: TransformerList = {
       transformerFunction: { kind: "datasetCreator", func: sort },
       info: {
         summary:
-          "Takes a dataset and orders it, using the value of a formula to \
-          determine how cases should appear in order.",
+          'Takes a dataset and orders its cases, either by the values from a \
+          particular attribute (the "By Attribute" method), or the values \
+          produced by a formula (the "By Expression" method).',
         consumes:
-          "A dataset to sort, a formula ('key expression'), an indication of the \
-          type the formula evaluates to, and a sort direction (ascending or descending).",
+          "By Attribute: A dataset to sort, an attribute to sort by, and a sort \
+          direction (ascending or descending).\n\
+          By Expression: A dataset to sort, a formula, an indication of the type \
+          the formula evaluates to, and a sort direction (ascending or descending).",
         produces:
-          "A copy of the input dataset, with cases sorted by the value of the \
-          key expression.",
+          "A copy of the input dataset, with cases sorted according to the \
+          indicated method and direction.",
         docLink: docLinkFromHeadingID("h.9swamcujp916"),
       },
     },

--- a/src/transformers/__tests__/sort.test.ts
+++ b/src/transformers/__tests__/sort.test.ts
@@ -354,7 +354,7 @@ test("sorts objects by attribute", async () => {
       "",
       "Boundaries",
       withObjects,
-      "ascending",
+      "ascending"
     )
   ).toEqual(sortedWithObjectsAsc);
 
@@ -367,7 +367,7 @@ test("sorts objects by attribute", async () => {
       "",
       "Boundaries",
       withObjects,
-      "descending",
+      "descending"
     )
   ).toEqual(sortedWithObjectsDesc);
 
@@ -377,7 +377,7 @@ test("sorts objects by attribute", async () => {
       "",
       "Boundary",
       TYPES_DATASET,
-      "ascending",
+      "ascending"
     )
   ).toEqual(TYPES_DATASET);
   expect(
@@ -385,7 +385,7 @@ test("sorts objects by attribute", async () => {
       "",
       "Boundary",
       TYPES_DATASET,
-      "descending",
+      "descending"
     )
   ).toEqual(TYPES_DATASET);
 });
@@ -474,12 +474,7 @@ test("sort is stable by attribute", async () => {
   };
 
   expect(
-    await uncheckedSortByAttributeWrapper(
-      "",
-      "Number",
-      dataset,
-      "ascending",
-    )
+    await uncheckedSortByAttributeWrapper("", "Number", dataset, "ascending")
   ).toEqual({
     collections: dataset.collections,
     records: makeRecords(

--- a/src/transformers/__tests__/sort.test.ts
+++ b/src/transformers/__tests__/sort.test.ts
@@ -1,5 +1,9 @@
 import { evalExpression } from "../../lib/codapPhone";
-import { SortDirection, uncheckedSort } from "../sort";
+import {
+  SortDirection,
+  uncheckedSortByAttribute,
+  uncheckedSortByExpression,
+} from "../sort";
 import { CodapLanguageType, DataSet } from "../types";
 import {
   cloneDataSet,
@@ -17,14 +21,14 @@ import {
 /**
  * A wrapper around unchecked sort that discards the missing value report.
  */
-async function uncheckedSortWrapper(
+async function uncheckedSortByExpressionWrapper(
   dataset: DataSet,
   keyExpr: string,
   outputType: CodapLanguageType,
   sortDirection: SortDirection,
   evalFormula = evalExpression
 ): Promise<DataSet> {
-  const [output] = await uncheckedSort(
+  const [output] = await uncheckedSortByExpression(
     dataset,
     keyExpr,
     outputType,
@@ -34,9 +38,27 @@ async function uncheckedSortWrapper(
   return output;
 }
 
+/**
+ * A wrapper around unchecked sort that discards the missing value report.
+ */
+async function uncheckedSortByAttributeWrapper(
+  contextName: string,
+  attribute: string,
+  dataset: DataSet,
+  sortDirection: SortDirection
+): Promise<DataSet> {
+  const [output] = await uncheckedSortByAttribute(
+    contextName,
+    dataset,
+    attribute,
+    sortDirection
+  );
+  return output;
+}
+
 test("no change to dataset with no records", async () => {
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       EMPTY_RECORDS,
       "A",
       "Any",
@@ -54,7 +76,7 @@ test("sorts numbers", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "A",
       "Any",
@@ -70,13 +92,35 @@ test("sorts numbers", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "A",
       "Any",
       "descending",
       jsEvalExpression
     )
+  ).toEqual(sortedByADescending);
+});
+
+test("sorts numbers by attribute", async () => {
+  // ascending order
+  const sortedByAAscending = cloneDataSet(DATASET_A);
+  sortedByAAscending.records.sort(
+    (a, b) => (a["A"] as number) - (b["A"] as number)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "A", DATASET_A, "ascending")
+  ).toEqual(sortedByAAscending);
+
+  // descending order
+  const sortedByADescending = cloneDataSet(DATASET_A);
+  sortedByADescending.records.sort(
+    (a, b) => (b["A"] as number) - (a["A"] as number)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "A", DATASET_A, "descending")
   ).toEqual(sortedByADescending);
 });
 
@@ -94,7 +138,7 @@ test("sorts booleans", async () => {
     ]
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "B",
       "Any",
@@ -116,13 +160,47 @@ test("sorts booleans", async () => {
     ]
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_A,
       "B",
       "Any",
       "ascending",
       jsEvalExpression
     )
+  ).toEqual(sortedByBAscending);
+});
+
+test("sorts booleans by attribute", async () => {
+  // descending is true before false
+  const sortedByBDescending = cloneDataSet(DATASET_A);
+  sortedByBDescending.records = makeRecords(
+    ["A", "B", "C"],
+    [
+      [3, true, 2000],
+      [8, true, 2003],
+      [4, true, 2010],
+      [10, false, 1998],
+      [10, false, 2014],
+    ]
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper("", "B", DATASET_A, "descending")
+  ).toEqual(sortedByBDescending);
+
+  // ascending is true before false
+  const sortedByBAscending = cloneDataSet(DATASET_A);
+  sortedByBAscending.records = makeRecords(
+    ["A", "B", "C"],
+    [
+      [10, false, 1998],
+      [10, false, 2014],
+      [3, true, 2000],
+      [8, true, 2003],
+      [4, true, 2010],
+    ]
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper("", "B", DATASET_A, "ascending")
   ).toEqual(sortedByBAscending);
 });
 
@@ -143,7 +221,7 @@ test("sorts strings", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_B,
       "Name",
       "Any",
@@ -158,13 +236,33 @@ test("sorts strings", async () => {
   );
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       DATASET_B,
       "Name",
       "Any",
       "descending",
       jsEvalExpression
     )
+  ).toEqual(sortedByNameDescending);
+});
+
+test("sorts strings by attribute", async () => {
+  const sortedByNameAscending = cloneDataSet(DATASET_B);
+  sortedByNameAscending.records.sort((aRec, bRec) =>
+    sortStr(aRec["Name"] as string, bRec["Name"] as string)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "Name", DATASET_B, "ascending")
+  ).toEqual(sortedByNameAscending);
+
+  const sortedByNameDescending = cloneDataSet(DATASET_B);
+  sortedByNameDescending.records.sort((aRec, bRec) =>
+    sortStr(bRec["Name"] as string, aRec["Name"] as string)
+  );
+
+  expect(
+    await uncheckedSortByAttributeWrapper("", "Name", DATASET_B, "descending")
   ).toEqual(sortedByNameDescending);
 });
 
@@ -188,7 +286,7 @@ test("sorts objects", async () => {
     sortStr(JSON.stringify(a["Boundaries"]), JSON.stringify(b["Boundaries"]))
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       withObjects,
       "Boundaries",
       "Any",
@@ -202,7 +300,7 @@ test("sorts objects", async () => {
     sortStr(JSON.stringify(b["Boundaries"]), JSON.stringify(a["Boundaries"]))
   );
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       withObjects,
       "Boundaries",
       "Any",
@@ -213,7 +311,7 @@ test("sorts objects", async () => {
 
   // All the boundaries are the same in the TYPES_DATASET
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       TYPES_DATASET,
       "Boundary",
       "Any",
@@ -222,7 +320,7 @@ test("sorts objects", async () => {
     )
   ).toEqual(TYPES_DATASET);
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       TYPES_DATASET,
       "Boundary",
       "Any",
@@ -232,10 +330,70 @@ test("sorts objects", async () => {
   ).toEqual(TYPES_DATASET);
 });
 
+test("sorts objects by attribute", async () => {
+  const withObjects = {
+    collections: [makeCollection("Collection", ["Boundaries"])],
+    records: makeRecords(
+      ["Boundaries"],
+      [
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+        [makeSimpleBoundary(true)],
+      ]
+    ),
+  };
+
+  const sortedWithObjectsAsc = cloneDataSet(withObjects);
+  sortedWithObjectsAsc.records.sort((a, b) =>
+    sortStr(JSON.stringify(a["Boundaries"]), JSON.stringify(b["Boundaries"]))
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundaries",
+      withObjects,
+      "ascending",
+    )
+  ).toEqual(sortedWithObjectsAsc);
+
+  const sortedWithObjectsDesc = cloneDataSet(withObjects);
+  sortedWithObjectsDesc.records.sort((a, b) =>
+    sortStr(JSON.stringify(b["Boundaries"]), JSON.stringify(a["Boundaries"]))
+  );
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundaries",
+      withObjects,
+      "descending",
+    )
+  ).toEqual(sortedWithObjectsDesc);
+
+  // All the boundaries are the same in the TYPES_DATASET
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundary",
+      TYPES_DATASET,
+      "ascending",
+    )
+  ).toEqual(TYPES_DATASET);
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Boundary",
+      TYPES_DATASET,
+      "descending",
+    )
+  ).toEqual(TYPES_DATASET);
+});
+
 test("errors when key expression evaluates to multiple types", async () => {
   expect.assertions(2);
   try {
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_3",
       "Any",
@@ -247,7 +405,7 @@ test("errors when key expression evaluates to multiple types", async () => {
   }
 
   try {
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       FULLY_FEATURED_DATASET,
       "Attribute_5",
       "Any",
@@ -276,12 +434,51 @@ test("sort is stable", async () => {
   };
 
   expect(
-    await uncheckedSortWrapper(
+    await uncheckedSortByExpressionWrapper(
       dataset,
       "Number",
       "Any",
       "ascending",
       jsEvalExpression
+    )
+  ).toEqual({
+    collections: dataset.collections,
+    records: makeRecords(
+      ["Letter", "Number"],
+      [
+        ["D", 1],
+        ["C", 2],
+        ["E", 2],
+        ["A", 3],
+        ["B", 3],
+        ["F", 6],
+      ]
+    ),
+  });
+});
+
+test("sort is stable by attribute", async () => {
+  const dataset = {
+    collections: [makeCollection("Collection", ["Letter", "Number"])],
+    records: makeRecords(
+      ["Letter", "Number"],
+      [
+        ["A", 3],
+        ["B", 3],
+        ["C", 2],
+        ["D", 1],
+        ["E", 2],
+        ["F", 6],
+      ]
+    ),
+  };
+
+  expect(
+    await uncheckedSortByAttributeWrapper(
+      "",
+      "Number",
+      dataset,
+      "ascending",
     )
   ).toEqual({
     collections: dataset.collections,

--- a/src/transformers/sort.ts
+++ b/src/transformers/sort.ts
@@ -238,14 +238,14 @@ export async function uncheckedSortByAttribute(
 
   const recordType = inferType(records.map((r) => r[attribute]));
   if (recordType === "Any") {
-      throw new Error(t("errors:sort.attributeTypeAny"));
+    throw new Error(t("errors:sort.attributeTypeAny"));
   }
 
   let sorted: Record<string, unknown>[] = [];
   switch (recordType) {
     case "Boolean":
       sorted = records
-        .map(r => {
+        .map((r) => {
           r[attribute] = toBool(r[attribute]);
           return r;
         })
@@ -257,7 +257,7 @@ export async function uncheckedSortByAttribute(
       break;
     case "Number":
       sorted = records
-        .map(r => {
+        .map((r) => {
           r[attribute] = Number(r[attribute]);
           return r;
         })
@@ -268,20 +268,18 @@ export async function uncheckedSortByAttribute(
         });
       break;
     case "String":
-      sorted = records
-        .sort((r1, r2) => {
-          return sortDirection === "ascending"
-            ? stringCompareFn(r1[attribute] as string, r2[attribute] as string)
-            : stringCompareFn(r2[attribute] as string, r1[attribute] as string);
-        });
+      sorted = records.sort((r1, r2) => {
+        return sortDirection === "ascending"
+          ? stringCompareFn(r1[attribute] as string, r2[attribute] as string)
+          : stringCompareFn(r2[attribute] as string, r1[attribute] as string);
+      });
       break;
     case "Boundary":
-      sorted = records
-        .sort((r1, r2) => {
-          return sortDirection === "ascending"
-            ? objectCompareFn(r1[attribute], r2[attribute])
-            : objectCompareFn(r2[attribute], r1[attribute]);
-        });
+      sorted = records.sort((r1, r2) => {
+        return sortDirection === "ascending"
+          ? objectCompareFn(r1[attribute], r2[attribute])
+          : objectCompareFn(r2[attribute], r1[attribute]);
+      });
       break;
   }
 


### PR DESCRIPTION
Resolves #224.

Changes:
- Add toggle component which is a dropdown where each option hides certain other components.
- Add sorting by attribute.

TODO:
- [x] Initialization issue: toggle value (by attribute or by expression) is initialized to null, even though it looks like it is set to "byAttribute" by default. If the user does not touch the toggle, sort will fail because toggle is null.
- [x] Comparison function issue: we need to be looser with types in our comparison function. Currently we do not detect numeric strings and sort them as strings instead.