### PR TITLE
Allow new attribute name for transformed attribute

### DIFF
--- a/src/strings/en/errors.ts
+++ b/src/strings/en/errors.ts
@@ -139,6 +139,8 @@ const errors = {
     noOutputType: "Please enter an output type",
     invalidAttribute:
       'Please select a valid attribute to transform: "{{ name }}" was not found',
+    noTransformedAttributeName:
+      "Please enter a name for the transformed attribute",
   },
   codapPhone: {
     updateInteractiveFrame: {

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -188,6 +188,9 @@ const transformerList: TransformerList = {
           title:
             "For each row, replace the value of attribute {attribute1} with the result of the expression:",
         },
+        textInput1: {
+          title: "New Name for Transformed Attribute",
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: transformAttribute },
       info: {


### PR DESCRIPTION
Users can now provide a new name for the attribute they are transforming with Transform Attribute, which makes sense because the transformed version may have a totally different interpretation or type from the original.

![Transform-Attribute-New-Name](https://user-images.githubusercontent.com/13399527/169857416-c6fe535b-2dba-43bb-8a28-671fc1073b5c.png)
