### PR TITLE
Add customizable placeholder text for formula expression editors

### DIFF
--- a/src/components/transformer-template/TransformerTemplate.tsx
+++ b/src/components/transformer-template/TransformerTemplate.tsx
@@ -69,7 +69,9 @@ interface DropdownInit extends ComponentInit {
     value: string;
   }[];
 }
-interface ExpressionInit extends ComponentInit {}
+interface ExpressionInit extends ComponentInit {
+  placeholder?: string;
+}
 interface TypeContractInit extends ComponentInit {
   inputTypes: string[] | string;
   inputTypeDisabled?: boolean;
@@ -601,6 +603,7 @@ const TransformerTemplate = (props: TransformerTemplateProps): ReactElement => {
               {displayExpressionPrompt(component, init, state)}
               <ExpressionEditor
                 value={state[component]}
+                placeholder={init[component]?.placeholder || "Expression"}
                 onChange={(s) => setState({ [component]: s })}
                 attributeNames={attributes[
                   attributeSetFromExpression(component) as

--- a/src/components/ui-components/ExpressionEditor.tsx
+++ b/src/components/ui-components/ExpressionEditor.tsx
@@ -44,6 +44,7 @@ CodeMirror.defineSimpleMode("codapFormula", {
 
 interface ExpressionEditorProps {
   value: string;
+  placeholder: string;
   onChange: (value: string) => void;
   attributeNames?: string[];
   disabled?: boolean;
@@ -92,6 +93,7 @@ const LOOKUP_FUNCTIONS_CATEGORY = "Lookup Functions";
 
 export default function ExpressionEditor({
   value,
+  placeholder,
   onChange,
   attributeNames = [],
   disabled,
@@ -170,7 +172,7 @@ export default function ExpressionEditor({
             hint: codapFormulaHints,
           },
           readOnly: disabled,
-          placeholder: "Expression",
+          placeholder,
         }}
         onInputRead={(editor) => {
           editor.showHint();

--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -148,6 +148,7 @@ const transformerList: TransformerList = {
         expression1: {
           title:
             "For each row, construct the attribute {textInput1} with the result of the expression:",
+          placeholder: "e.g. Age + 10",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: buildAttribute },
@@ -187,6 +188,7 @@ const transformerList: TransformerList = {
         expression1: {
           title:
             "For each row, replace the value of attribute {attribute1} with the result of the expression:",
+          placeholder: "e.g. Height * 2",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: transformAttribute },
@@ -219,7 +221,10 @@ const transformerList: TransformerList = {
           inputTypeDisabled: true,
           outputTypeDisabled: true,
         },
-        expression1: { title: "Keep all rows that satisfy:" },
+        expression1: {
+          title: "Keep all rows that satisfy:",
+          placeholder: "e.g. Year > 1990",
+        },
       },
       transformerFunction: { kind: "datasetCreator", func: filter },
       info: {
@@ -250,6 +255,7 @@ const transformerList: TransformerList = {
         expression1: {
           title:
             "Sort the rows in this dataset by a value, which is computed by:",
+          placeholder: "e.g. stringLength(Name)",
         },
         dropdown1: {
           title: "Direction",
@@ -546,9 +552,11 @@ const transformerList: TransformerList = {
         },
         expression1: {
           title: "Starting with:",
+          placeholder: "e.g. 0",
         },
         expression2: {
           title: "Compute the next value for each row by:",
+          placeholder: "e.g. Age + Accumulator",
         },
       },
       transformerFunction: { kind: "datasetCreator", func: genericFold },


### PR DESCRIPTION
Addresses a comment from #239.

This allows us to specify custom placeholders for expression editors, with the goal of helping students think about what a potential expression might look like for a given transformer.

I am not at all set on the placeholders I've chosen so far, they are just a proof-of-concept. Some things to consider:
- How do we give example expressions in a way that doesn't confuse the student? Currently I've included attribute names that are made-up, and so entering verbatim what's in the placeholder will cause an error (unless they're on a dataset that happens to have that attribute name), but is this necessarily an issue?
- Is including text like "e.g." helpful? Or it would it be better blank or with something else?

Example:
![placeholder](https://user-images.githubusercontent.com/13399527/170085717-e60605bd-335d-44b5-aa68-6a6739563f0e.png)
