### PR TITLE
Prevent saving transformers with duplicate names

### DIFF
--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -19,9 +19,11 @@ export default function DefinitionCreator({
   const [saveErr, setSaveErr] = useState<string | null>(null);
 
   async function saveTransformer(data: TransformerSaveData) {
-    const { name, purposeStatement } = data;
+    let { name, purposeStatement } = data;
 
-    if (name.trim() === "") {
+    name = name.trim();
+
+    if (name === "") {
       setSaveErr("Please give the transformer a name before saving.");
       return;
     }

--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from "react";
 import { BaseTransformerName } from "../../transformerList";
 import { SavedTransformerContent, TransformerSaveData } from "./types";
-import { createDataInteractive } from "../../lib/codapPhone";
+import { createDataInteractive, getAllComponents } from "../../lib/codapPhone";
 import "./styles/DefinitionCreator.css";
 import ErrorDisplay from "../ui-components/Error";
 
@@ -18,11 +18,19 @@ export default function DefinitionCreator({
 }: DefinitionCreatorProps): ReactElement {
   const [saveErr, setSaveErr] = useState<string | null>(null);
 
-  function saveTransformer(data: TransformerSaveData) {
+  async function saveTransformer(data: TransformerSaveData) {
     const { name, purposeStatement } = data;
 
     if (name.trim() === "") {
       setSaveErr("Please give the transformer a name before saving.");
+      return;
+    }
+
+    // Make sure a transformer with this name doesn't exist already
+    const components = await getAllComponents();
+    const full_name = `Transformer: ${name}`;
+    if (components.find((c) => c.title === full_name)) {
+      setSaveErr("A transformer with that name already exists");
       return;
     }
 
@@ -38,7 +46,7 @@ export default function DefinitionCreator({
 
     const savedUrl = new URL(window.location.toString());
     savedUrl.searchParams.append("transform", encoded);
-
+    console.log(name);
     createDataInteractive(name, savedUrl.toString());
   }
 

--- a/src/components/transformer-template/DefinitionCreator.tsx
+++ b/src/components/transformer-template/DefinitionCreator.tsx
@@ -46,7 +46,7 @@ export default function DefinitionCreator({
 
     const savedUrl = new URL(window.location.toString());
     savedUrl.searchParams.append("transform", encoded);
-    console.log(name);
+
     createDataInteractive(name, savedUrl.toString());
   }
 

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -163,13 +163,15 @@ function SavedDefinitionView({
           // clear the transformer application error message
           setErrMsg(null, errorId);
 
+          const new_name = savedTransformer.name.trim();
+
           // if going to non-editable (saving) and name is blank
-          if (editable && savedTransformer.name.trim() === "") {
+          if (editable && new_name === "") {
             setSaveErr("Please choose a name for the transformer");
             return;
           }
 
-          const full_name = `Transformer: ${savedTransformer.name}`;
+          const full_name = `Transformer: ${new_name}`;
 
           // check if trying to save with a name that another transformer already uses
           if (editable) {

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -197,6 +197,9 @@ function SavedDefinitionView({
             });
           }
 
+          // ensure that whitespace trimming is reflected in textbox
+          setSavedTransformer({ ...savedTransformer, name: new_name });
+
           setEditable(!editable);
         }}
         title={

--- a/src/views/SavedDefinitionView.tsx
+++ b/src/views/SavedDefinitionView.tsx
@@ -8,6 +8,7 @@ import ErrorDisplay, {
 import { SavedTransformer } from "../components/transformer-template/types";
 import { TextInput } from "../components/ui-components";
 import {
+  getAllComponents,
   getInteractiveFrame,
   notifyInteractiveFrameIsDirty,
   updateInteractiveFrame,
@@ -158,7 +159,7 @@ function SavedDefinitionView({
       />
       <button
         id="edit-button"
-        onClick={() => {
+        onClick={async () => {
           // clear the transformer application error message
           setErrMsg(null, errorId);
 
@@ -168,10 +169,29 @@ function SavedDefinitionView({
             return;
           }
 
+          const full_name = `Transformer: ${savedTransformer.name}`;
+
+          // check if trying to save with a name that another transformer already uses
+          if (editable) {
+            const components = await getAllComponents();
+            const currentName = (await getInteractiveFrame()).title;
+
+            // Add an extra clause to the conditional to allow a duplicate name if
+            // we're just saving this transformer with the name it already had
+            if (
+              components.find(
+                (c) => c.title === full_name && c.title !== currentName
+              )
+            ) {
+              setSaveErr("A transformer with that name already exists");
+              return;
+            }
+          }
+
           // if saving, update the interactive frame to use the new transformer name
           if (editable) {
             updateInteractiveFrame({
-              title: `Transformer: ${savedTransformer.name}`,
+              title: full_name,
             });
           }
 


### PR DESCRIPTION
Adds an error message when trying to save a transformer with the same name as an existing transformer

![image](https://user-images.githubusercontent.com/40366824/171490430-0f759bd2-d0ca-4105-ad50-dd41bd1abfce.png)
