### PR TITLE
Fix Reduce name placeholder

### DIFF
--- a/src/transformerList.ts
+++ b/src/transformerList.ts
@@ -654,7 +654,7 @@ const transformerList: TransformerList = {
     componentData: {
       init: {
         name: {
-          placeholder: "e.g., total-number-of-toes",
+          placeholder: "e.g., total-age",
         },
         context1: {
           title: "Dataset to Reduce",


### PR DESCRIPTION
In accordance with #247, this updates the placeholder Transformer name text for Reduce to match the placeholder text for its expressions (which suggest a running sum of an Age attribute).