### PR TITLE
Use user-defined names in generated table titles

### DIFF
--- a/src/transformers/buildAttribute.ts
+++ b/src/transformers/buildAttribute.ts
@@ -21,6 +21,7 @@ export async function buildAttribute({
   textInput1: attributeName,
   expression1: expression,
   typeContract1: { outputType },
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -51,9 +52,11 @@ export async function buildAttribute({
 
   mvr.extraInfo = `The formula for the new column evaluated to a missing value for ${mvr.missingValues.length} rows.`;
 
+  name = name || "BuildAttribute";
+
   return [
     withColumn,
-    `BuildAttribute(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with a new attribute (${attributeName}) added to ` +
       `the ${collectionName} collection, whose value is determined by the formula \`${expression}\`.`,
     mvr,

--- a/src/transformers/combineCases.ts
+++ b/src/transformers/combineCases.ts
@@ -18,6 +18,7 @@ import { t } from "../strings";
 export async function combineCases({
   context1: inputDataContext1,
   context2: inputDataContext2,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (!inputDataContext1 || !inputDataContext2) {
     throw new Error(t("errors:combineCases.noDataSet"));
@@ -32,9 +33,11 @@ export async function combineCases({
   const ctxtName1 = tryTitle(context1);
   const ctxtName2 = tryTitle(context2);
 
+  name = name || "CombinedCases";
+
   return [
     await uncheckedCombineCases(dataset1, dataset2),
-    `CombinedCases(${ctxtName1}, ${ctxtName2})`,
+    `${name}(${ctxtName1}, ${ctxtName2})`,
     `A copy of ${ctxtName1}, containing all of the cases from both ${ctxtName1} and ${ctxtName2}.`,
     EMPTY_MVR,
   ];

--- a/src/transformers/compare.ts
+++ b/src/transformers/compare.ts
@@ -33,6 +33,7 @@ export async function compare({
   attribute1: inputAttribute1,
   attribute2: inputAttribute2,
   dropdown1: kind,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (!inputDataContext1) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -80,9 +81,11 @@ export async function compare({
       `attributes. Rows with missing values were ignored in the comparison and left ` +
       `with a missing difference value.`;
 
+    name = name || "Compare";
+
     return [
       numeric,
-      `Compare(${contextTitle}, ...)`,
+      `${name}(${contextTitle}, ...)`,
       `A numeric comparison of the attributes ${inputAttribute1} and ${inputAttribute2} (from ${contextTitle})`,
       mvr,
     ];

--- a/src/transformers/copy.ts
+++ b/src/transformers/copy.ts
@@ -9,6 +9,7 @@ import { t } from "../strings";
  */
 export async function copy({
   context1: contextName,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -16,10 +17,11 @@ export async function copy({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
+  name = name || "UneditableCopy";
 
   return [
     await uncheckedCopy(dataset),
-    `UneditableCopy(${ctxtName})`,
+    `${name}(${ctxtName})`,
     `An uneditable copy of the ${ctxtName} dataset.`,
     EMPTY_MVR,
   ];

--- a/src/transformers/copyStructure.ts
+++ b/src/transformers/copyStructure.ts
@@ -10,6 +10,7 @@ import { t } from "../strings";
  */
 export async function copyStructure({
   context1: contextName,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -17,10 +18,11 @@ export async function copyStructure({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
+  name = name || "CopyStructure";
 
   return [
     await uncheckedCopyStructure(dataset),
-    `CopyStructure(${ctxtName})`,
+    `${name}(${ctxtName})`,
     `A copy of the collections and attributes of the ${ctxtName} dataset, but with no cases.`,
     EMPTY_MVR,
   ];

--- a/src/transformers/count.ts
+++ b/src/transformers/count.ts
@@ -27,6 +27,7 @@ import { t } from "../strings";
 export async function count({
   context1: contextName,
   attributeSet1: attributes,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -43,9 +44,11 @@ export async function count({
 
   mvr.extraInfo = `${mvr.missingValues.length} missing values were encountered in the counted attributes.`;
 
+  name = name || "Count";
+
   return [
     counted,
-    `Count(${contextTitle}, ...)`,
+    `${name}(${contextTitle}, ...)`,
     `A summary of the frequency of all tuples of the ${pluralSuffix(
       "attribute",
       attributes

--- a/src/transformers/filter.ts
+++ b/src/transformers/filter.ts
@@ -12,6 +12,7 @@ import { t } from "../strings";
 export async function filter({
   context1: contextName,
   expression1: predicate,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -23,9 +24,11 @@ export async function filter({
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
 
+  name = name || "Filter";
+
   return [
     await uncheckedFilter(dataset, predicate),
-    `Filter(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} that only includes the cases for which the predicate \`${predicate}\` is true.`,
     // TODO: MVR? requires analysis of formula
     EMPTY_MVR,

--- a/src/transformers/flatten.ts
+++ b/src/transformers/flatten.ts
@@ -11,6 +11,7 @@ import { t } from "../strings";
  */
 export async function flatten({
   context1: contextName,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -18,10 +19,11 @@ export async function flatten({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
+  name = name || "Flatten";
 
   return [
     await uncheckedFlatten(dataset),
-    `Flatten(${ctxtName})`,
+    `${name}(${ctxtName})`,
     `A copy of ${ctxtName} in which all collections have been flattened into one collection.`,
     EMPTY_MVR,
   ];

--- a/src/transformers/fold.ts
+++ b/src/transformers/fold.ts
@@ -34,6 +34,7 @@ function makeFoldWrapper(
   return async ({
     context1: contextName,
     attribute1: inputAttributeName,
+    name,
   }: TransformerTemplateState): Promise<TransformationOutput> => {
     if (contextName === null) {
       throw new Error(t("errors:validation.noDataSet"));
@@ -65,12 +66,10 @@ function makeFoldWrapper(
       attributeDescription
     );
 
-    return [
-      folded,
-      `${label.replace(/\s+/, "")}(${contextTitle}, ...)`,
-      datasetDescription,
-      mvr,
-    ];
+    const defaultName = label.replace(/\s+/, "");
+    name = name || defaultName;
+
+    return [folded, `${name}(${contextTitle}, ...)`, datasetDescription, mvr];
   };
 }
 
@@ -147,6 +146,7 @@ export async function genericFold({
   expression1: base,
   textInput2: accumulatorName,
   expression2: expression,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -180,9 +180,11 @@ export async function genericFold({
 
   mvr.extraInfo = `The reduce formula evaluated to a missing value for ${mvr.missingValues.length} rows.`;
 
+  name = name || "Reduce";
+
   return [
     reduced,
-    `Reduce(${contextTitle}, ...)`,
+    `${name}(${contextTitle}, ...)`,
     `A reduce of the ${contextTitle} dataset, with an attribute ${resultColumnName} ` +
       `whose values are determined by the formula \`${expression}\`. ` +
       `The accumulator is named ${accumulatorName} and its initial value is \`${base}\`.`,
@@ -339,6 +341,7 @@ export async function differenceFrom({
   context1: contextName,
   attribute1: inputAttributeName,
   textInput2: startingValue,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -373,9 +376,11 @@ export async function differenceFrom({
     Number(startingValue)
   );
 
+  name = name || "DifferenceFrom";
+
   return [
     diffFrom,
-    `DifferenceFrom(${contextTitle}, ...)`,
+    `${name}(${contextTitle}, ...)`,
     `A copy of ${contextTitle} with a new column whose values are the difference between ` +
       `the value of ${inputAttributeName} in the current case and the value of ${inputAttributeName} ` +
       `in the case above. The first case subtracts ${startingValue} from itself.`,

--- a/src/transformers/groupBy.ts
+++ b/src/transformers/groupBy.ts
@@ -25,6 +25,7 @@ import { t } from "../strings";
 export async function groupBy({
   context1: contextName,
   attributeSet1: attributes,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -54,9 +55,11 @@ export async function groupBy({
 
   mvr.extraInfo = `${mvr.missingValues.length} missing values were encountered in the grouped attributes.`;
 
+  name = name || "GroupBy";
+
   return [
     grouped,
-    `GroupBy(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with a new parent collection added ` +
       `which contains a copy of the ${pluralSuffix(
         "attribute",

--- a/src/transformers/join.ts
+++ b/src/transformers/join.ts
@@ -25,6 +25,7 @@ export async function innerJoin({
   context2: inputDataContext2,
   attribute1: inputAttribute1,
   attribute2: inputAttribute2,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (
     !inputDataContext1 ||
@@ -58,9 +59,11 @@ export async function innerJoin({
     `attribute. The copied attributes from the joining dataset were left missing ` +
     `for such rows with missing values.`;
 
+  name = name || "InnerJoin";
+
   return [
     joined,
-    `InnerJoin(${ctxtName1}, ${ctxtName2}, ...)`,
+    `${name}(${ctxtName1}, ${ctxtName2}, ...)`,
     `A copy of ${ctxtName1}, with all the attributes/values from the collection ` +
       `containing ${inputAttribute2} in ${ctxtName2} added into the collection ` +
       `containing ${inputAttribute1} in ${ctxtName1}.`,
@@ -153,6 +156,7 @@ export async function outerJoin({
   attribute1: inputAttribute1,
   attribute2: inputAttribute2,
   dropdown1: kind,
+  name: transformerName,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (
     !inputDataContext1 ||
@@ -179,7 +183,8 @@ export async function outerJoin({
   const ctxtName1 = tryTitle(context1);
   const ctxtName2 = tryTitle(context2);
 
-  const name = `OuterJoin(${ctxtName1}, ${ctxtName2}, ...)`;
+  transformerName = transformerName || "OuterJoin";
+  const name = `${transformerName}(${ctxtName1}, ${ctxtName2}, ...)`;
   const description =
     `A copy of ${ctxtName1}, with all the attributes/values from the collection ` +
     `containing ${inputAttribute2} in ${ctxtName2} added into the collection ` +

--- a/src/transformers/mean.ts
+++ b/src/transformers/mean.ts
@@ -11,6 +11,7 @@ import { t } from "../strings";
 export async function mean({
   context1: contextName,
   attribute1: attribute,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -30,9 +31,11 @@ export async function mean({
     `while computing the mean, and were ignored. The mean you see is the mean ` +
     `of the non-missing values.`;
 
+  name = name || "Mean";
+
   return [
     meanValue,
-    `Mean(${ctxtName}, ${attribute})`,
+    `${name}(${ctxtName}, ${attribute})`,
     `The mean value of the ${attribute} attribute in the ${ctxtName} dataset.`,
     mvr,
   ];

--- a/src/transformers/median.ts
+++ b/src/transformers/median.ts
@@ -11,6 +11,7 @@ import { t } from "../strings";
 export async function median({
   context1: contextName,
   attribute1: attribute,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -30,9 +31,11 @@ export async function median({
     `while computing the median, and were ignored. The median you see is the median ` +
     `of the non-missing values.`;
 
+  name = name || "Median";
+
   return [
     medianValue,
-    `Median(${ctxtName}, ${attribute})`,
+    `${name}(${ctxtName}, ${attribute})`,
     `The median value of the ${attribute} attribute in the ${ctxtName} dataset.`,
     mvr,
   ];

--- a/src/transformers/mode.ts
+++ b/src/transformers/mode.ts
@@ -11,6 +11,7 @@ import { t } from "../strings";
 export async function mode({
   context1: contextName,
   attribute1: attribute,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -30,9 +31,11 @@ export async function mode({
     `while computing the mode, and were ignored. The mode values you see are the modes ` +
     `of the non-missing values.`;
 
+  name = name || "Mode";
+
   return [
     modes,
-    `Mode(${ctxtName}, ${attribute})`,
+    `${name}(${ctxtName}, ${attribute})`,
     `The mode value of the ${attribute} attribute in the ${ctxtName} dataset.`,
     mvr,
   ];

--- a/src/transformers/pivot.ts
+++ b/src/transformers/pivot.ts
@@ -23,6 +23,7 @@ export async function pivotLonger({
   attributeSet1: attributes,
   textInput1: namesTo,
   textInput2: valuesTo,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -40,10 +41,11 @@ export async function pivotLonger({
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
   const attributeNames = listAsString(attributes);
+  name = name || "PivotLonger";
 
   return [
     uncheckedPivotLonger(dataset, attributes, namesTo, valuesTo),
-    `PivotLonger(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with the ${pluralSuffix(
       "attribute",
       attributes
@@ -148,6 +150,7 @@ export async function pivotWider({
   context1: contextName,
   attribute1: namesFrom,
   attribute2: valuesFrom,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -161,9 +164,10 @@ export async function pivotWider({
 
   const { context, dataset } = await getContextAndDataSet(contextName);
   const ctxtName = tryTitle(context);
+  name = name || "PivotWider";
   return [
     uncheckedPivotWider(dataset, namesFrom, valuesFrom),
-    `PivotWider(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with the values in attribute ${namesFrom} converted ` +
       `into new attributes, which get their values from the attribute ${valuesFrom}.`,
     EMPTY_MVR,

--- a/src/transformers/selectAttributes.ts
+++ b/src/transformers/selectAttributes.ts
@@ -20,6 +20,7 @@ export async function selectAttributes({
   context1: contextName,
   attributeSet1: attributes,
   dropdown1: mode,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -35,9 +36,11 @@ export async function selectAttributes({
   const ctxtName = tryTitle(context);
   const attributeNames = listAsString(attributes);
 
+  name = name || "SelectAttributes";
+
   return [
     await uncheckedSelectAttributes(dataset, attributes, allBut),
-    `SelectAttributes(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName} with ${
       allBut ? "all but" : "only"
     } the ${pluralSuffix("attribute", attributes)} ${attributeNames} included.`,

--- a/src/transformers/sort.ts
+++ b/src/transformers/sort.ts
@@ -81,6 +81,7 @@ export async function sort({
   expression1: expression,
   dropdown1: sortDirection,
   typeContract1: { outputType },
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -88,15 +89,19 @@ export async function sort({
   if (!isSortDirection(sortDirection)) {
     throw new Error(t("errors:sort.noSortDirection"));
   }
+
+  name = name || "Sort";
+
   if (toggle === "byAttribute") {
-    return await sortByAttribute(contextName, attribute, sortDirection);
+    return await sortByAttribute(contextName, attribute, sortDirection, name);
   }
   if (toggle === "byExpression") {
     return await sortbyExpression(
       contextName,
       expression,
       sortDirection,
-      outputType
+      outputType,
+      name
     );
   }
   throw new Error(t("errors:sort.noSortMethod"));
@@ -106,7 +111,8 @@ export async function sortbyExpression(
   contextName: string,
   expression: string,
   sortDirection: SortDirection,
-  outputType: CodapLanguageType
+  outputType: CodapLanguageType,
+  name: string
 ): Promise<TransformationOutput> {
   if (expression.trim() === "") {
     throw new Error(t("errors:sort.noKeyExpression"));
@@ -126,7 +132,7 @@ export async function sortbyExpression(
 
   return [
     sorted,
-    `Sort(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName}, sorted by the value of the key formula: \`${expression}\`.`,
     mvr,
   ];
@@ -180,7 +186,8 @@ export async function uncheckedSortByExpression(
 export async function sortByAttribute(
   contextName: string,
   attribute: string | null,
-  sortDirection: SortDirection
+  sortDirection: SortDirection,
+  name: string
 ): Promise<TransformationOutput> {
   if (attribute === null) {
     throw new Error(t("errors:sort.noSortAttribute"));
@@ -200,7 +207,7 @@ export async function sortByAttribute(
 
   return [
     sorted,
-    `Sort(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName}, sorted by the attribute: \`${attribute}\`.`,
     mvr,
   ];

--- a/src/transformers/standardDeviation.ts
+++ b/src/transformers/standardDeviation.ts
@@ -11,6 +11,7 @@ import { t } from "../strings";
 export async function standardDeviation({
   context1: contextName,
   attribute1: attribute,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -34,9 +35,11 @@ export async function standardDeviation({
     `the standard deviation, and were ignored. The standard deviation you see is ` +
     `the standard deviation of the non-missing values.`;
 
+  name = name || "StandardDeviation";
+
   return [
     stdDev,
-    `StandardDeviation(${ctxtName}, ${attribute})`,
+    `${name}(${ctxtName}, ${attribute})`,
     `The standard deviation of the ${attribute} attribute in the ${ctxtName} dataset.`,
     mvr,
   ];

--- a/src/transformers/sumProduct.ts
+++ b/src/transformers/sumProduct.ts
@@ -16,6 +16,7 @@ import { t } from "../strings";
 export async function sumProduct({
   context1: contextName,
   attributeSet1: attributes,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -35,12 +36,14 @@ export async function sumProduct({
     `${mvr.missingValues.length} missing values were encountered while computing ` +
     `the sum product. Any row which contained missing values was ignored.`;
 
+  name = name || "SumProduct";
+
   // NOTE: The output name uses {} instead of [] to show the list of attributes
   // below because [] causes problems in data context names and (through MVR)
   // the name of this sum product may appear in a data context.
   return [
     sumProd,
-    `SumProduct(${ctxtName}, {${attributes.join(", ")}})`,
+    `${name}(${ctxtName}, {${attributes.join(", ")}})`,
     `The sum across all cases in ${ctxtName} of the product ` +
       `of the ${pluralSuffix("attribute", attributes)} ${attributeNames}.`,
     mvr,

--- a/src/transformers/transformAttribute.ts
+++ b/src/transformers/transformAttribute.ts
@@ -22,6 +22,7 @@ export async function transformAttribute({
   expression1: expression,
   typeContract1: { outputType },
   textInput1: transformedAttributeName,
+  name,
 }: TransformerTemplateState): Promise<TransformationOutput> {
   if (contextName === null) {
     throw new Error(t("errors:validation.noDataSet"));
@@ -53,9 +54,11 @@ export async function transformAttribute({
 
   mvr.extraInfo = `The formula for the transformed column evaluated to a missing value for ${mvr.missingValues.length} rows.`;
 
+  name = name || "TransformAttribute";
+
   return [
     transformed,
-    `TransformAttribute(${ctxtName}, ...)`,
+    `${name}(${ctxtName}, ...)`,
     `A copy of ${ctxtName}, with the ${attributeName} attribute transformed into ` +
       `${transformedAttributeName}, with its values determined by the formula \`${expression}\`.`,
     mvr,


### PR DESCRIPTION
- When applying a transformer, if the name field is not empty, use the name of the transformer in the title of generated tables.
- The only transformer that hasn't been changed is "Editable Copy". The original generated name does not follow the functional format of "Transform(Input)", but says "Editable Copy of X".
- Currently, if you save a transformer, apply it, and edit its name, the name edits do not flow. Is this the behavior we want?